### PR TITLE
docs: add StrainRate and RotationRate to operator lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,8 @@ Gaussian(0.5) # Smaller ε = wider basis function
 | Normal derivative ∂f/∂n | `normal_derivative(points, normals)` | Vector |
 | Divergence of vector field | `divergence(points)` | Vector (from N×D matrix) |
 | Curl of vector field | `curl(points)` | 2D: Vector, 3D: N×3 Matrix |
+| Strain rate ½(∇u + (∇u)ᵀ) | `strain_rate(points)` | Array (N × D × D) |
+| Rotation rate ½(∇u − (∇u)ᵀ) | `rotation_rate(points)` | Array (N × D × D) |
 | Diffusion ∇⋅(κ∇f) | `(@operator ∇ ⋅ (κ * ∇))(points)` | Vector |
 | Interpolate to new points | `regrid(src, dst)` | Vector |
 | Global interpolation | `Interpolator(points, values)` | Callable object |

--- a/docs/src/guides/operators.md
+++ b/docs/src/guides/operators.md
@@ -40,6 +40,8 @@ AbstractOperator{N}
 │   ├── Curl             ∇×u (vector field → scalar/vector)
 │   ├── Identity         f (function itself)
 │   ├── ScaledOperator   α * op
+│   ├── StrainRate       ½(∇u + (∇u)ᵀ)
+│   ├── RotationRate     ½(∇u − (∇u)ᵀ)
 │   ├── Regrid           interpolation to new points
 │   └── Custom{0}        user-defined / algebra result
 ├── N=1 (rank-adding)

--- a/docs/src/guides/quickref.md
+++ b/docs/src/guides/quickref.md
@@ -71,6 +71,8 @@ diff = (@operator ∇ ⋅ (κ * ∇))(points)          # ∇⋅(κ∇f)
 # Vector field operators (input: N×D matrix)
 div_op = divergence(points)       # ∇⋅u (scalar output)
 curl_op = curl(points)            # ∇×u (2D: scalar, 3D: vector)
+S = strain_rate(points)           # ½(∇u + (∇u)ᵀ)
+R = rotation_rate(points)         # ½(∇u − (∇u)ᵀ)
 
 # Interpolation operators
 rg = regrid(source, target)       # Local interpolation


### PR DESCRIPTION
## Summary

- Add `StrainRate` and `RotationRate` to the operator type hierarchy in `docs/src/guides/operators.md`
- Add `strain_rate` and `rotation_rate` to the quick reference in `docs/src/guides/quickref.md`
- Add both operators to the operator selection table in `CLAUDE.md`

These operators were added in #118 but missing from the documentation lists.