### PR TITLE
feat(operators): add mul! interface and operator trait system

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -7,5 +7,5 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 BenchmarkTools = "1.5"
-RadialBasisFunctions = "0.3, 0.4"
+RadialBasisFunctions = "0.3, 0.4, 0.5"
 julia = "1.10"

--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -102,6 +102,10 @@ export Interpolator
 include("operators/regridding.jl")
 export Regrid, regrid
 
+include("operators/operator_traits.jl")
+export output_rank, requires_vector_input, is_symmetric, is_antisymmetric
+export is_self_adjoint, derivative_order
+
 # Some consts and aliases
 const Δ = ∇² # some people like this notation for the Laplacian
 const AVOID_INF = 1.0e-16

--- a/src/operators/curl.jl
+++ b/src/operators/curl.jl
@@ -24,15 +24,6 @@ end
 # Evaluation
 # ============================================================================
 
-function _eval_op(op::RadialBasisOperator{<:Curl}, x::AbstractVector)
-    throw(
-        ArgumentError(
-            "Curl requires a vector field (Matrix input, N×D), got a Vector. " *
-                "Each column should be a component of the vector field."
-        )
-    )
-end
-
 # 2D curl: (N×2) → (N,)  =  ∂u₂/∂x₁ − ∂u₁/∂x₂
 function _eval_op(op::RadialBasisOperator{<:Curl{2}}, x::AbstractMatrix)
     N_eval = length(op.eval_points)

--- a/src/operators/divergence.jl
+++ b/src/operators/divergence.jl
@@ -17,15 +17,6 @@ end
 # Evaluation — vector field input only
 # ============================================================================
 
-function _eval_op(op::RadialBasisOperator{<:Divergence}, x::AbstractVector)
-    throw(
-        ArgumentError(
-            "Divergence requires a vector field (Matrix input, N×D), got a Vector. " *
-                "Each column should be a component of the vector field."
-        )
-    )
-end
-
 function _eval_op(op::RadialBasisOperator{<:Divergence}, x::AbstractMatrix)
     D = length(op.weights)
     N_eval = length(op.eval_points)

--- a/src/operators/operator_algebra.jl
+++ b/src/operators/operator_algebra.jl
@@ -86,6 +86,19 @@ for op in (:+, :-)
     end
 end
 
+# Catch rank-mismatched operator algebra with a clear error
+for op in (:+, :-)
+    @eval function Base.$op(op1::AbstractOperator, op2::AbstractOperator)
+        throw(
+            ArgumentError(
+                "Cannot combine operators with different output ranks: " *
+                    "$(print_op(op1)) (rank $(output_rank(op1))) and " *
+                    "$(print_op(op2)) (rank $(output_rank(op2)))"
+            )
+        )
+    end
+end
+
 function _check_compatible(op1::RadialBasisOperator, op2::RadialBasisOperator)
     if (length(op1.data) != length(op2.data)) || !all(op1.data .≈ op2.data)
         throw(

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -1,0 +1,78 @@
+# ============================================================================
+# Operator Traits
+# ============================================================================
+#
+# Trait functions that describe operator properties for dispatch, validation,
+# and introspection. These enable better error messages at construction time
+# and allow generic code to query operator capabilities.
+
+"""
+    output_rank(op::AbstractOperator{N}) -> Int
+
+Tensor rank added to the output by this operator. Returns `N` from the type parameter.
+"""
+output_rank(::AbstractOperator{N}) where {N} = N
+
+"""
+    requires_vector_input(op) -> Bool
+
+Whether the operator requires a vector field (matrix) as input rather than a scalar field (vector).
+Operators like [`Divergence`](@ref), [`Curl`](@ref), [`StrainRate`](@ref), and
+[`RotationRate`](@ref) act on vector fields and will error on scalar input.
+"""
+requires_vector_input(::AbstractOperator) = false
+requires_vector_input(::Divergence) = true
+requires_vector_input(::Curl) = true
+requires_vector_input(::StrainRate) = true
+requires_vector_input(::RotationRate) = true
+
+"""
+    is_symmetric(op) -> Bool
+
+Whether the operator produces a symmetric output tensor. Symmetric operators can
+exploit storage savings (e.g., only storing upper-triangular entries).
+"""
+is_symmetric(::AbstractOperator) = false
+is_symmetric(::Hessian) = true
+is_symmetric(::StrainRate) = true
+
+"""
+    is_antisymmetric(op) -> Bool
+
+Whether the operator produces an anti-symmetric output tensor (Aᵢⱼ = −Aⱼᵢ).
+"""
+is_antisymmetric(::AbstractOperator) = false
+is_antisymmetric(::RotationRate) = true
+
+"""
+    is_self_adjoint(op) -> Bool
+
+Whether the operator is self-adjoint (⟨ℒu, v⟩ = ⟨u, ℒv⟩). Self-adjoint operators
+produce symmetric weight matrices, which matters for solver selection and
+eigenvalue problems.
+"""
+is_self_adjoint(::AbstractOperator) = false
+is_self_adjoint(::Laplacian) = true
+is_self_adjoint(::Identity) = true
+is_self_adjoint(::Regrid) = false
+
+"""
+    derivative_order(op) -> Int
+
+Total order of differentiation. Useful for estimating required polynomial degree
+and stencil size.
+"""
+derivative_order(::Identity) = 0
+derivative_order(::Regrid) = 0
+derivative_order(op::Partial) = op.order
+derivative_order(::MixedPartial) = 2
+derivative_order(::Laplacian) = 2
+derivative_order(::Jacobian) = 1
+derivative_order(::Hessian) = 2
+derivative_order(::Directional) = 1
+derivative_order(::Divergence) = 1
+derivative_order(::Curl) = 1
+derivative_order(::StrainRate) = 1
+derivative_order(::RotationRate) = 1
+derivative_order(s::ScaledOperator) = derivative_order(s.op)
+derivative_order(::Custom) = -1  # unknown

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -75,4 +75,6 @@ derivative_order(::Curl) = 1
 derivative_order(::StrainRate) = 1
 derivative_order(::RotationRate) = 1
 derivative_order(s::ScaledOperator) = derivative_order(s.op)
-derivative_order(::Custom) = -1  # unknown
+function derivative_order(::Custom)
+    throw(ArgumentError("derivative_order is not defined for Custom operators"))
+end

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -234,6 +234,19 @@ end
 _eval_op(op::RadialBasisOperator, x) = op.weights * x
 _eval_op(op::RadialBasisOperator, y, x) = mul!(y, op.weights, x)
 
+# Generic error for operators that require vector field (matrix) input
+function _eval_op(op::RadialBasisOperator, x::AbstractVector)
+    if requires_vector_input(op.ℒ)
+        throw(
+            ArgumentError(
+                "$(print_op(op.ℒ)) requires a vector field (Matrix input, N×D), got a Vector. " *
+                    "Each column should be a component of the vector field."
+            )
+        )
+    end
+    return op.weights * x
+end
+
 # Rank-1 operator weights: Scalar field input → Matrix output (N×D)
 function _eval_op(
         op::RadialBasisOperator{<:AbstractOperator{1}}, x::AbstractVector
@@ -504,6 +517,52 @@ function _eval_op(
     return y
 end
 
+# ============================================================================
+# LinearAlgebra.mul! interface
+# ============================================================================
+
+"""
+    LinearAlgebra.mul!(y, op::RadialBasisOperator, x)
+    LinearAlgebra.mul!(y, op::RadialBasisOperator, x, α, β)
+
+Standard linear algebra interface for operator application: `y = op * x` or `y = α * op * x + β * y`.
+
+This makes `RadialBasisOperator` composable with iterative solvers (Krylov.jl),
+LinearMaps.jl, and any generic Julia code expecting a `mul!`-compatible linear map.
+
+Only defined for rank-0 operators with scalar (non-tuple) weights, since `mul!` expects
+a single linear map `y = A * x`.
+"""
+function LinearAlgebra.mul!(
+        y, op::RadialBasisOperator{<:AbstractOperator{0}}, x
+    )
+    !is_cache_valid(op) && update_weights!(op)
+    return _eval_op(op, y, x)
+end
+
+function LinearAlgebra.mul!(
+        y, op::RadialBasisOperator{<:AbstractOperator{0}}, x,
+        α::Number, β::Number,
+    )
+    !is_cache_valid(op) && update_weights!(op)
+    return mul!(y, op.weights, x, α, β)
+end
+
+"""
+    Base.size(op::RadialBasisOperator{<:AbstractOperator{0}})
+
+Return the dimensions `(m, n)` of the operator's weight matrix.
+Only defined for rank-0 operators with scalar weights.
+"""
+Base.size(op::RadialBasisOperator{<:AbstractOperator{0}}) = size(op.weights)
+
+"""
+    Base.eltype(op::RadialBasisOperator)
+
+Return the element type of the operator's weight matrix.
+"""
+Base.eltype(op::RadialBasisOperator) = eltype(op.weights)
+
 # LinearAlgebra methods - divergence (dot with gradient operator)
 function LinearAlgebra.:⋅(
         op::RadialBasisOperator{<:AbstractOperator{1}}, x::AbstractVector
@@ -550,9 +609,22 @@ function Adapt.adapt_structure(to, op::RadialBasisOperator{<:AbstractOperator, <
 end
 
 # pretty printing
+function _format_traits(ℒ::AbstractOperator)
+    traits = String[]
+    requires_vector_input(ℒ) && push!(traits, "vector-field input")
+    is_self_adjoint(ℒ) && push!(traits, "self-adjoint")
+    is_symmetric(ℒ) && push!(traits, "symmetric")
+    is_antisymmetric(ℒ) && push!(traits, "antisymmetric")
+    return join(traits, ", ")
+end
+
 function Base.show(io::IO, op::RadialBasisOperator)
     println(io, "RadialBasisOperator")
     println(io, "├─Operator: " * print_op(op.ℒ))
+    traits_str = _format_traits(op.ℒ)
+    if !isempty(traits_str)
+        println(io, "├─Properties: ", traits_str)
+    end
     println(io, "├─Data type: ", eltype(op.data))
     println(io, "├─Number of points: ", length(op.data))
     println(io, "├─Stencil size: ", length(first(op.adjl)))

--- a/src/operators/rotation_rate.jl
+++ b/src/operators/rotation_rate.jl
@@ -17,15 +17,6 @@ end
 # Evaluation — vector field input only
 # ============================================================================
 
-function _eval_op(op::RadialBasisOperator{<:RotationRate}, x::AbstractVector)
-    throw(
-        ArgumentError(
-            "RotationRate requires a vector field (Matrix input, N×D), got a Vector. " *
-                "Each column should be a component of the vector field."
-        )
-    )
-end
-
 function _eval_op(op::RadialBasisOperator{<:RotationRate}, x::AbstractMatrix)
     D = length(op.weights)
     N_eval = length(op.eval_points)

--- a/src/operators/strain_rate.jl
+++ b/src/operators/strain_rate.jl
@@ -17,15 +17,6 @@ end
 # Evaluation — vector field input only
 # ============================================================================
 
-function _eval_op(op::RadialBasisOperator{<:StrainRate}, x::AbstractVector)
-    throw(
-        ArgumentError(
-            "StrainRate requires a vector field (Matrix input, N×D), got a Vector. " *
-                "Each column should be a component of the vector field."
-        )
-    )
-end
-
 function _eval_op(op::RadialBasisOperator{<:StrainRate}, x::AbstractMatrix)
     D = length(op.weights)
     N_eval = length(op.eval_points)

--- a/test/operators/operator_algebra.jl
+++ b/test/operators/operator_algebra.jl
@@ -33,6 +33,12 @@ adjl[2] = dx.adjl[1]
 dy = partial(x, 1, 2; adjl = adjl)
 @test_throws ArgumentError dx + dy
 
+# test rank-mismatched algebra gives clear error
+@testset "Rank mismatch error" begin
+    @test_throws ArgumentError Laplacian() + Jacobian{2}()
+    @test_throws ArgumentError Partial(1, 1) - Hessian{2}()
+end
+
 # ScaledOperator algebra
 @testset "ScaledOperator" begin
     p = Partial(1, 1)

--- a/test/operators/operator_traits.jl
+++ b/test/operators/operator_traits.jl
@@ -66,4 +66,5 @@ end
     @test derivative_order(StrainRate{2}()) == 1
     @test derivative_order(RotationRate{3}()) == 1
     @test derivative_order(2.0 * Laplacian()) == 2
+    @test_throws ArgumentError derivative_order(Custom{0}(identity))
 end

--- a/test/operators/operator_traits.jl
+++ b/test/operators/operator_traits.jl
@@ -1,0 +1,69 @@
+using RadialBasisFunctions
+using StaticArraysCore
+
+@testset "output_rank" begin
+    @test output_rank(Laplacian()) == 0
+    @test output_rank(Partial(1, 1)) == 0
+    @test output_rank(MixedPartial(1, 2)) == 0
+    @test output_rank(Directional{2}(ones(2))) == 0
+    @test output_rank(Divergence{2}()) == 0
+    @test output_rank(Curl{2}()) == 0
+    @test output_rank(StrainRate{2}()) == 0
+    @test output_rank(RotationRate{2}()) == 0
+    @test output_rank(Identity()) == 0
+    @test output_rank(Jacobian{2}()) == 1
+    @test output_rank(Hessian{2}()) == 2
+    @test output_rank(2.0 * Laplacian()) == 0
+    @test output_rank(3.0 * Jacobian{2}()) == 1
+end
+
+@testset "requires_vector_input" begin
+    @test !requires_vector_input(Laplacian())
+    @test !requires_vector_input(Partial(1, 1))
+    @test !requires_vector_input(Jacobian{2}())
+    @test !requires_vector_input(Hessian{2}())
+    @test !requires_vector_input(Identity())
+    @test requires_vector_input(Divergence{2}())
+    @test requires_vector_input(Curl{3}())
+    @test requires_vector_input(StrainRate{2}())
+    @test requires_vector_input(RotationRate{3}())
+end
+
+@testset "is_symmetric" begin
+    @test !is_symmetric(Laplacian())
+    @test !is_symmetric(Jacobian{2}())
+    @test !is_symmetric(Divergence{2}())
+    @test is_symmetric(Hessian{2}())
+    @test is_symmetric(StrainRate{2}())
+end
+
+@testset "is_antisymmetric" begin
+    @test !is_antisymmetric(Laplacian())
+    @test !is_antisymmetric(StrainRate{2}())
+    @test is_antisymmetric(RotationRate{2}())
+end
+
+@testset "is_self_adjoint" begin
+    @test is_self_adjoint(Laplacian())
+    @test is_self_adjoint(Identity())
+    @test !is_self_adjoint(Partial(1, 1))
+    @test !is_self_adjoint(Jacobian{2}())
+    @test !is_self_adjoint(Regrid())
+end
+
+@testset "derivative_order" begin
+    @test derivative_order(Identity()) == 0
+    @test derivative_order(Regrid()) == 0
+    @test derivative_order(Partial(1, 1)) == 1
+    @test derivative_order(Partial(2, 1)) == 2
+    @test derivative_order(MixedPartial(1, 2)) == 2
+    @test derivative_order(Laplacian()) == 2
+    @test derivative_order(Jacobian{2}()) == 1
+    @test derivative_order(Hessian{2}()) == 2
+    @test derivative_order(Directional{2}(ones(2))) == 1
+    @test derivative_order(Divergence{2}()) == 1
+    @test derivative_order(Curl{3}()) == 1
+    @test derivative_order(StrainRate{2}()) == 1
+    @test derivative_order(RotationRate{3}()) == 1
+    @test derivative_order(2.0 * Laplacian()) == 2
+end

--- a/test/operators/operators.jl
+++ b/test/operators/operators.jl
@@ -71,6 +71,36 @@ end
     @test RBF.dim(∂3d) == 3
 end
 
+@testset "LinearAlgebra.mul! interface" begin
+    # Rank-0: mul!(y, op, x)
+    ∂ = partial(x, 1, 1)
+    z = rand(rng, N)
+    y1 = similar(z)
+    y2 = similar(z)
+    ∂(y1, z)
+    mul!(y2, ∂, z)
+    @test y1 ≈ y2
+
+    # Rank-0: 5-arg mul!(y, op, x, α, β)
+    α, β = 2.5, -0.3
+    y3 = rand(rng, N)
+    y_ref = copy(y3)
+    mul!(y3, ∂, z, α, β)
+    @test y3 ≈ α * (∂.weights * z) + β * y_ref
+
+    # Laplacian (also rank-0)
+    ∇² = laplacian(x)
+    y4 = similar(z)
+    y5 = similar(z)
+    ∇²(y4, z)
+    mul!(y5, ∇², z)
+    @test y4 ≈ y5
+
+    # size and eltype
+    @test size(∂) == size(∂.weights)
+    @test eltype(∂) == eltype(∂.weights)
+end
+
 @testset "Printing" begin
     ∂ = partial(x, 1, 1)
     @test repr(∂) == """

--- a/test/operators/operators.jl
+++ b/test/operators/operators.jl
@@ -112,4 +112,9 @@ end
     @test contains(r, "└─Basis: Polyharmonic spline (r³) with degree 2 polynomial augmentation")
 
     @test RBF.print_op(∂.ℒ) == "∂ⁿf/∂xᵢ (n = 1, i = 1)"
+
+    # operator with traits shown
+    ∇² = laplacian(x)
+    r_lap = repr(∇²)
+    @test contains(r_lap, "├─Properties: self-adjoint")
 end

--- a/test/operators/operators.jl
+++ b/test/operators/operators.jl
@@ -103,14 +103,13 @@ end
 
 @testset "Printing" begin
     ∂ = partial(x, 1, 1)
-    @test repr(∂) == """
-        RadialBasisOperator
-        ├─Operator: ∂ⁿf/∂xᵢ (n = 1, i = 1)
-        ├─Data type: StaticArraysCore.SVector{2, Float64}
-        ├─Number of points: 100
-        ├─Stencil size: 12
-        └─Basis: Polyharmonic spline (r³) with degree 2 polynomial augmentation
-        """
+    r = repr(∂)
+    @test contains(r, "RadialBasisOperator")
+    @test contains(r, "├─Operator: ∂ⁿf/∂xᵢ (n = 1, i = 1)")
+    @test contains(r, "SVector{2, Float64}")
+    @test contains(r, "├─Number of points: 100")
+    @test contains(r, "├─Stencil size: 12")
+    @test contains(r, "└─Basis: Polyharmonic spline (r³) with degree 2 polynomial augmentation")
 
     @test RBF.print_op(∂.ℒ) == "∂ⁿf/∂xᵢ (n = 1, i = 1)"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,10 @@ end
     include("operators/operator_algebra.jl")
 end
 
+@safetestset "Operator Traits" begin
+    include("operators/operator_traits.jl")
+end
+
 @safetestset "Device Kwarg" begin
     include("operators/device_kwarg.jl")
 end


### PR DESCRIPTION
## Summary
- Add `LinearAlgebra.mul!` (3-arg and 5-arg) plus `size`/`eltype` for rank-0 operators, making them composable with Krylov.jl, LinearMaps.jl, and any generic `mul!`-based code
- Add operator trait functions (`output_rank`, `requires_vector_input`, `is_symmetric`, `is_antisymmetric`, `is_self_adjoint`, `derivative_order`) for introspection and dispatch
- Consolidate duplicated vector-input error messages (Divergence, Curl, StrainRate, RotationRate) into a single generic check using `requires_vector_input`
- Add rank-mismatch error for operator algebra (`Laplacian() + Jacobian{2}()`)
- Show operator traits in `show` output
- Make printing test robust to Julia version differences