### PR TITLE
ci(format-check): install Julia so runic-action can run

### DIFF
--- a/.github/workflows/FormatPR.yml
+++ b/.github/workflows/FormatPR.yml
@@ -14,6 +14,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+            - uses: julia-actions/setup-julia@v2
+              with:
+                  version: "1"
             - uses: fredrikekre/runic-action@v1
               with:
                   version: "1"


### PR DESCRIPTION
`fredrikekre/runic-action@v1` (v1.4+) requires `julia` in `PATH` but no longer installs it itself. Without a `julia-actions/setup-julia@v2` step before it, the format check has been silently passing — i.e. silently failing.

Upstream context: [`SciML/OrdinaryDiffEqOperatorSplitting.jl#74`](https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl/pull/74).