### PR TITLE
chore(ci): align Dependabot config with JuliaPackageTemplate.jl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,21 @@
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-enable-beta-ecosystems: true # Julia ecosystem
 updates:
+  # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-  - package-ecosystem: "julia"
-    directories:
-      - "/"
-      - "/docs"
-    schedule:
-      interval: "daily"
     groups:
-      all-julia-packages:
+      github-actions:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "Statistics"
-      - dependency-name: "LinearAlgebra"
-      - dependency-name: "Random"
+
+  # Keep Julia dependencies up to date
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      julia-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Standardizes `.github/dependabot.yml` and `.github/workflows/dependabot-automerge.yml` to the verbatim contents of `RallypointOne/JuliaPackageTemplate.jl`, and removes any legacy CompatHelper workflow.

Part of an org-wide sweep across Kyle's Julia repos.