### PR TITLE
fix: correctness fixes — Hermite guards, input validation, reorder_points!, Regrid dispatch

### DIFF
--- a/src/operators/regridding.jl
+++ b/src/operators/regridding.jl
@@ -3,11 +3,8 @@
 
 Operator for interpolating from one set of points to another.
 """
-struct Regrid <: AbstractOperator{0}
-    ℒ::typeof(identity)
-    Regrid() = new(identity)
-end
-(op::Regrid)(x) = op.ℒ(x)
+struct Regrid <: AbstractOperator{0} end
+(::Regrid)(basis::AbstractBasis) = basis
 
 # Primary interface using unified keyword constructor
 """

--- a/src/solve/api.jl
+++ b/src/solve/api.jl
@@ -73,6 +73,48 @@ end
 # Hermite Path (With Boundary Conditions)
 # ============================================================================
 
+_supports_normal_form(f, x, n) = applicable(f, x, x, n)
+_supports_normal_form(fs::Tuple, x, n) = all(f -> _supports_normal_form(f, x, n), fs)
+
+function _check_normal_form_support(ℒrbf, basis, data, boundary_conditions, normals)
+    needs_normal = any(bc -> is_neumann(bc) || is_robin(bc), boundary_conditions)
+    if needs_normal && !_supports_normal_form(ℒrbf, first(data), first(normals))
+        throw(
+            ArgumentError(
+                "Neumann/Robin boundary conditions require the operator's basis action to " *
+                    "support the normal-derivative form ℒrbf(x, xᵢ, normal), which is not " *
+                    "implemented for $(typeof(ℒrbf)) with $(nameof(typeof(basis))). Normal-form " *
+                    "methods currently exist only for PHS bases with the ∂, ∇, ∂², and ∇² " *
+                    "operators. For IMQ/Gaussian support, see " *
+                    "https://github.com/JuliaMeshless/RadialBasisFunctions.jl/issues/136",
+            ),
+        )
+    end
+    return nothing
+end
+
+function _validate_boundary_inputs(data, is_boundary, boundary_conditions, normals)
+    if length(is_boundary) != length(data)
+        throw(
+            DimensionMismatch(
+                "length(is_boundary) = $(length(is_boundary)) must equal the number of " *
+                    "data points ($(length(data)))",
+            ),
+        )
+    end
+    n_boundary = count(is_boundary)
+    if length(boundary_conditions) != n_boundary || length(normals) != n_boundary
+        throw(
+            DimensionMismatch(
+                "boundary_conditions ($(length(boundary_conditions))) and normals " *
+                    "($(length(normals))) must each have one entry per boundary point " *
+                    "(count(is_boundary) = $n_boundary)",
+            ),
+        )
+    end
+    return nothing
+end
+
 """
     _build_weights(data, eval_points, adjl, basis, ℒrbf, ℒmon, mon,
                   is_boundary, boundary_conditions, normals;
@@ -95,6 +137,8 @@ function _build_weights(
         batch_size::Int = 10,
         device = CPU(),
     )
+    _validate_boundary_inputs(data, is_boundary, boundary_conditions, normals)
+    _check_normal_form_support(ℒrbf, basis, data, boundary_conditions, normals)
     boundary_data = BoundaryData(is_boundary, boundary_conditions, normals)
     return build_weights_kernel(
         data,

--- a/src/solve/backward.jl
+++ b/src/solve/backward.jl
@@ -238,7 +238,11 @@ function _backward_partial_polynomial_section!(
     elseif D == 3
         _backward_partial_poly_3d!(Δeval_point, Δb, k, nmon, dim, num_ops)
     else
-        error("Polynomial backward pass not implemented for D=$D (only D=1,2,3 supported)")
+        throw(
+            ArgumentError(
+                "Polynomial backward pass not implemented for D=$D (only D=1,2,3 supported)",
+            ),
+        )
     end
     return nothing
 end

--- a/src/solve/types.jl
+++ b/src/solve/types.jl
@@ -74,10 +74,21 @@ struct HermiteStencilData{T <: Real}
             normals::AbstractVector{<:AbstractVector{T}},
             poly_workspace::Vector{T} = Vector{T}(undef, 0),
         ) where {T <: Real}
-        @assert length(data) ==
-            length(is_boundary) ==
-            length(boundary_conditions) ==
-            length(normals)
+        if !(
+                length(data) ==
+                    length(is_boundary) ==
+                    length(boundary_conditions) ==
+                    length(normals)
+            )
+            throw(
+                DimensionMismatch(
+                    "HermiteStencilData requires equal lengths, got data = " *
+                        "$(length(data)), is_boundary = $(length(is_boundary)), " *
+                        "boundary_conditions = $(length(boundary_conditions)), " *
+                        "normals = $(length(normals))",
+                ),
+            )
+        end
 
         # Convert to Vector{Vector{T}} for internal storage
         data_vectors = [Vector{T}(point) for point in data]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,11 +38,11 @@ function autoselect_k(data::AbstractVector, basis::B) where {B <: AbstractRadial
 end
 
 function reorder_points!(
-        x::AbstractVector, adjl::AbstractVector{AbstractVector{T}}, k::T
+        x::AbstractVector, adjl::AbstractVector{<:AbstractVector{T}}, k::T
     ) where {T <: Int}
-    i = symrcm(adjl, ones(T, length(x)) .* k)
+    i = symrcm(adjl, fill(k, length(x)))
     permute!(x, i)
-    return nothing
+    return i
 end
 
 function reorder_points!(x::AbstractVector, k::T) where {T <: Int}

--- a/test/boundary_types.jl
+++ b/test/boundary_types.jl
@@ -132,7 +132,7 @@ end
         bcs = [Dirichlet(), Neumann()]
         normals = [[1.0, 0.0], [0.0, 1.0]]
 
-        @test_throws AssertionError RBF.HermiteStencilData(data, is_boundary, bcs, normals)
+        @test_throws DimensionMismatch RBF.HermiteStencilData(data, is_boundary, bcs, normals)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ end
     include("basis/monomial.jl")
 end
 
+@safetestset "Utilities" begin
+    include("utils.jl")
+end
+
 @safetestset "Operators" begin
     include("operators/operators.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,180 @@
+using Test
+using StaticArraysCore
+using RadialBasisFunctions
+import RadialBasisFunctions as RBF
+
+# 12-point 2D domain with 2 boundary points at (0,0) and (1,0), mirrors test/hermite.jl
+function create_2d_domain()
+    data = [
+        SVector(0.0, 0.0),   # boundary
+        SVector(0.15, 0.1),
+        SVector(0.2, 0.25),
+        SVector(0.3, 0.15),
+        SVector(0.4, 0.3),
+        SVector(0.5, 0.2),
+        SVector(0.6, 0.35),
+        SVector(0.7, 0.25),
+        SVector(0.75, 0.15),
+        SVector(0.85, 0.3),
+        SVector(0.9, 0.2),
+        SVector(1.0, 0.0),   # boundary
+    ]
+    is_boundary = vcat(true, fill(false, 10), true)
+    normals = [SVector(1.0, 0.0), SVector(-1.0, 0.0)]
+    return data, is_boundary, normals
+end
+
+@testset "find_neighbors" begin
+    points = [SVector(0.0, 0.0), SVector(1.0, 0.0), SVector(0.0, 1.0), SVector(2.0, 2.0)]
+
+    adjl = find_neighbors(points, 2)
+    @test length(adjl) == length(points)
+    @test all(length.(adjl) .== 2)
+    @test adjl[1][1] == 1  # sorted output → each point is its own nearest neighbor
+    @test adjl[1][2] in (2, 3)  # (1,0) and (0,1) are equidistant from (0,0)
+    @test adjl[4][2] != 1  # (0,0) is the farthest point from (2,2)
+
+    eval_points = [SVector(0.9, 0.1)]
+    adjl_eval = find_neighbors(points, eval_points, 3)
+    @test length(adjl_eval) == length(eval_points)
+    @test length(adjl_eval[1]) == 3
+    @test adjl_eval[1][1] == 2  # nearest data point to (0.9, 0.1) is (1,0)
+end
+
+@testset "autoselect_k" begin
+    points = [SVector(0.01 * i, 0.02 * i^2) for i in 1:50]
+
+    # Bayona: min(N, max(2*binomial(m+d, d), 2d+1)) with d=2
+    @test RBF.autoselect_k(points, PHS(3; poly_deg = 2)) == 12  # 2*binomial(4,2)
+    @test RBF.autoselect_k(points, PHS(3; poly_deg = 1)) == 6   # 2*binomial(3,2)
+    @test RBF.autoselect_k(points, PHS(3; poly_deg = 0)) == 5   # 2d+1 dominates
+    @test RBF.autoselect_k(points[1:5], PHS(3; poly_deg = 2)) == 5  # clamped to N
+end
+
+@testset "check_poly_deg" begin
+    @test RBF.check_poly_deg(-1) === nothing
+    @test RBF.check_poly_deg(2) === nothing
+    @test_throws ArgumentError RBF.check_poly_deg(-2)
+end
+
+@testset "reorder_points!" begin
+    original = [SVector(float(i), 0.5 * i) for i in 10:-1:1]
+    k = 3
+
+    # 2-arg exported form (was a MethodError before the dispatch fix)
+    points = copy(original)
+    perm = reorder_points!(points, k)
+    @test perm isa Vector{Int}
+    @test isperm(perm)
+    @test points == original[perm]
+
+    # 3-arg form with precomputed adjacency
+    points = copy(original)
+    adjl = find_neighbors(points, k)
+    perm3 = reorder_points!(points, adjl, k)
+    @test isperm(perm3)
+    @test points == original[perm3]
+end
+
+@testset "Hermite basis-support guard" begin
+    data, is_boundary, normals = create_2d_domain()
+    neumann = (is_boundary = is_boundary, bc = [Neumann(), Neumann()], normals = normals)
+    dirichlet = (is_boundary = is_boundary, bc = [Dirichlet(), Dirichlet()], normals = normals)
+
+    # Neumann/Robin BCs need the 3-arg normal form — only PHS implements it (issue #136)
+    @test_throws ArgumentError RadialBasisOperator(
+        Laplacian(), data; basis = IMQ(1.0; poly_deg = 2), hermite = neumann
+    )
+    @test_throws ArgumentError RadialBasisOperator(
+        Laplacian(), data; basis = Gaussian(1.0; poly_deg = 2), hermite = neumann
+    )
+    robin = (is_boundary = is_boundary, bc = [Robin(1.0, 1.0), Robin(1.0, 1.0)], normals = normals)
+    @test_throws ArgumentError RadialBasisOperator(
+        Laplacian(), data; basis = IMQ(1.0; poly_deg = 2), hermite = robin
+    )
+
+    # Tuple-valued actions (gradient family) route through the same guard
+    @test_throws ArgumentError RadialBasisOperator(
+        Jacobian{2}(), data; basis = IMQ(1.0; poly_deg = 2), hermite = neumann
+    )
+
+    # PHS supports the normal form — build must succeed and produce finite values
+    op = RadialBasisOperator(
+        Laplacian(), data; basis = PHS(3; poly_deg = 2), hermite = neumann
+    )
+    u = [x[2]^2 for x in data]  # ∂u/∂n = 0 on both boundaries
+    @test all(isfinite, op(u))
+
+    op_jac = RadialBasisOperator(
+        Jacobian{2}(), data; basis = PHS(3; poly_deg = 2), hermite = neumann
+    )
+    @test op_jac isa RadialBasisOperator
+
+    # Dirichlet-only never evaluates the normal form — IMQ/Gaussian must not trip the guard
+    op_imq = RadialBasisOperator(
+        Laplacian(), data; basis = IMQ(1.0; poly_deg = 2), hermite = dirichlet
+    )
+    @test all(isfinite, op_imq(u))
+    op_gauss = RadialBasisOperator(
+        Laplacian(), data; basis = Gaussian(1.0; poly_deg = 2), hermite = dirichlet
+    )
+    @test all(isfinite, op_gauss(u))
+end
+
+@testset "boundary input validation" begin
+    data, is_boundary, normals = create_2d_domain()
+    bc = [Neumann(), Neumann()]
+
+    # is_boundary must flag every data point
+    @test_throws DimensionMismatch RadialBasisOperator(
+        Laplacian(), data;
+        hermite = (is_boundary = is_boundary[1:5], bc = bc, normals = normals),
+    )
+    # one bc per boundary point
+    @test_throws DimensionMismatch RadialBasisOperator(
+        Laplacian(), data;
+        hermite = (is_boundary = is_boundary, bc = bc[1:1], normals = normals),
+    )
+    # one normal per boundary point
+    @test_throws DimensionMismatch RadialBasisOperator(
+        Laplacian(), data;
+        hermite = (is_boundary = is_boundary, bc = bc, normals = normals[1:1]),
+    )
+end
+
+@testset "HermiteStencilData length validation" begin
+    stencil_data = [[0.0, 0.0], [0.5, 0.0], [1.0, 0.0]]
+    bcs = [Internal(), Internal(), Internal()]
+    stencil_normals = [zeros(2) for _ in 1:3]
+
+    hd = HermiteStencilData(stencil_data, fill(false, 3), bcs, stencil_normals)
+    @test hd isa HermiteStencilData{Float64}
+
+    @test_throws DimensionMismatch HermiteStencilData(
+        stencil_data, fill(false, 2), bcs, stencil_normals
+    )
+    @test_throws DimensionMismatch HermiteStencilData(
+        stencil_data, fill(false, 3), bcs[1:2], stencil_normals
+    )
+    @test_throws DimensionMismatch HermiteStencilData(
+        stencil_data, fill(false, 3), bcs, stencil_normals[1:2]
+    )
+end
+
+@testset "Regrid action" begin
+    basis = PHS(3; poly_deg = 2)
+    @test Regrid()(basis) === basis
+    mon = MonomialBasis(2, 2)
+    @test Regrid()(mon) === mon
+
+    # calling with data now builds an operator (was a dispatch ambiguity MethodError)
+    data, _, _ = create_2d_domain()
+    @test Regrid()(data) isa RadialBasisOperator
+
+    # end-to-end regrid: poly_deg=2 reproduces a linear field exactly
+    targets = [SVector(0.3, 0.2), SVector(0.6, 0.25), SVector(0.8, 0.2)]
+    rg = regrid(data, targets)
+    field = [1.0 + 2.0 * x[1] - 0.5 * x[2] for x in data]
+    expected = [1.0 + 2.0 * x[1] - 0.5 * x[2] for x in targets]
+    @test rg(field) ≈ expected atol = 1.0e-8
+end


### PR DESCRIPTION
First PR of the systematic-review refactoring roadmap (correctness tier). Fixes four verified bugs and replaces silent/opaque failure modes with typed, descriptive errors.

## Changes

**Hermite basis-support guard** (`src/solve/api.jl`)
Neumann/Robin Hermite builds with IMQ/Gaussian bases used to die with a `MethodError` deep inside assembly — the 3-arg normal-derivative methods `ℒrbf(x, xᵢ, normal)` exist only for PHS (#136). An `applicable`-based check at the single weight-build choke point now raises a clear `ArgumentError` naming the supported combinations. Because it queries the method table at build time, it automatically accepts the IMQ/Gaussian methods once #136 lands — no guard changes needed. The `Internal` sentinel BC (α=0, β=0) never triggers the normal form and correctly does not trip the guard.

**Boundary-input validation** (`src/solve/api.jl`, `src/solve/types.jl`)
There was no up-front length checking of `is_boundary`/`bc`/`normals` (mismatches surfaced per-stencil, or worse). Now validated at entry with `DimensionMismatch`: `is_boundary` flags every data point; `bc` and `normals` carry one entry per boundary point (`count(is_boundary)`). `HermiteStencilData`'s inner-constructor `@assert` is likewise now a descriptive `DimensionMismatch`.

**`reorder_points!` repaired** (`src/utils.jl`)
The `adjl` argument's invariant type `AbstractVector{AbstractVector{T}}` could never match the `Vector{Vector{Int}}` returned by `find_neighbors`, so the exported 2-arg method has always thrown a `MethodError`. Fixed with the diagonal signature, and the function now returns the permutation so callers can permute co-located field arrays. Also `ones(T, n) .* k` → `fill(k, n)`.

**`Regrid` fieldless singleton** (`src/operators/regridding.jl`)
The `ℒ::typeof(identity)` field carried no information, and the unconstrained `(op::Regrid)(x)` was dispatch-ambiguous with `(op::AbstractOperator)(data::AbstractVector; kw...)` — `Regrid()(points)` threw a `MethodError`. The action is now `(::Regrid)(basis::AbstractBasis) = basis`, covering both radial and monomial bases; `Regrid()(points)` builds an operator like every other `AbstractOperator`.

**Typed error in AD backward** (`src/solve/backward.jl`)
`error(...)` → `ArgumentError` for unsupported polynomial backward dimensions.

## Tests

New `test/utils.jl` suite (wired into `runtests.jl`): `find_neighbors` both arities, `autoselect_k` against the Bayona formula, `check_poly_deg`, the repaired `reorder_points!` (both arities, permutation consistency), the Hermite guard (IMQ/Gaussian + Neumann/Robin throw; PHS + Neumann builds; Dirichlet-only IMQ/Gaussian must not trip; tuple-valued Jacobian action routes through the same guard), boundary-input validation, `HermiteStencilData` validation, and the `Regrid` action/end-to-end regrid. One stale expectation in `test/boundary_types.jl` updated (`AssertionError` → `DimensionMismatch`).

Full suite run locally: 1174 passed, 0 failed (including LuxCore/DifferentiationInterface/Mooncake extension suites).

Refs #136

---
<sub>🤖 Authored by Claude under adult supervision — Kyle approves the tiers, I just turn the wrenches.</sub>