### PR TITLE
Dead code, dependency trim, and test infrastructure (roadmap PR 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Manifest.toml
 # Local Claude Code artifacts
 .claude/
 
+
+# Syncthing/iCloud conflict copies
+*sync-conflict*

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["Kyle Beggs"]
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
@@ -14,7 +13,6 @@ NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 SymRCM = "286e6d88-80af-4590-acc9-0001b223b9bd"
 
@@ -31,7 +29,6 @@ RadialBasisFunctionsMooncakeExt = "Mooncake"
 
 [compat]
 Adapt = "4"
-ChunkSplitters = "3"
 Combinatorics = "1"
 Distances = "0.9, 0.10"
 Enzyme = "0.13"
@@ -42,7 +39,8 @@ LuxCore = "1"
 Mooncake = "0.5"
 NearestNeighbors = "0.4.8"
 PrecompileTools = "1.2"
-StaticArrays = "1.9.15"
+Random = "1"
+SparseArrays = "1"
 StaticArraysCore = "1.4"
 SymRCM = "0.2"
 julia = "1.10"

--- a/ext/RadialBasisFunctionsMooncakeExt/RadialBasisFunctionsMooncakeExt.jl
+++ b/ext/RadialBasisFunctionsMooncakeExt/RadialBasisFunctionsMooncakeExt.jl
@@ -17,7 +17,7 @@ module RadialBasisFunctionsMooncakeExt
 using RadialBasisFunctions
 using Mooncake
 using Mooncake: CoDual, NoFData, NoRData, primal, zero_fcodual
-using StaticArrays: SVector
+using StaticArraysCore: SVector
 using LinearAlgebra: Symmetric
 using SparseArrays: SparseMatrixCSC
 

--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -1,7 +1,6 @@
 module RadialBasisFunctions
 
 using Adapt
-using ChunkSplitters
 using Combinatorics
 using Distances
 using KernelAbstractions

--- a/src/basis/basis.jl
+++ b/src/basis/basis.jl
@@ -50,28 +50,6 @@ struct ∇²{B <: AbstractRadialBasis}
 end
 
 """
-    D{B<:AbstractRadialBasis,V}
-
-Directional derivative operator functor. Construct with `D(basis, v)`.
-Computes the derivative of the basis function in direction `v`.
-"""
-struct D{B <: AbstractRadialBasis, V}
-    basis::B
-    v::V
-end
-
-"""
-    D²{B<:AbstractRadialBasis,V1,V2}
-
-Directional second derivative operator functor. Construct with `D²(basis, v1, v2)`.
-"""
-struct D²{B <: AbstractRadialBasis, V1, V2}
-    basis::B
-    v1::V1
-    v2::V2
-end
-
-"""
     H{B<:AbstractRadialBasis}
 
 Hessian operator functor. Construct with `H(basis)`.

--- a/src/basis/basis.jl
+++ b/src/basis/basis.jl
@@ -83,14 +83,3 @@ function (op::∂mixed)(x, xᵢ)
     end
     return H(op.basis)(x, xᵢ)[op.dim1, op.dim2]
 end
-
-# pretty printing
-unicode_order(::Val{1}) = ""
-unicode_order(::Val{2}) = "²"
-unicode_order(::Val{3}) = "³"
-unicode_order(::Val{4}) = "⁴"
-unicode_order(::Val{5}) = "⁵"
-unicode_order(::Val{6}) = "⁶"
-unicode_order(::Val{7}) = "⁷"
-unicode_order(::Val{8}) = "⁸"
-unicode_order(::Val{9}) = "⁹"

--- a/src/basis/gaussian.jl
+++ b/src/basis/gaussian.jl
@@ -39,22 +39,6 @@ function (op::∇{<:Gaussian})(x, xᵢ)
     return -2 * ε2 * (x .- xᵢ) * exp(-ε2 * sqeuclidean(x, xᵢ))
 end
 
-# D - directional derivative
-function (op::D{<:Gaussian})(x, xᵢ)
-    ε2 = op.basis.ε^2
-    return -2 * ε2 * LinearAlgebra.dot(op.v, x .- xᵢ) * exp(-ε2 * sqeuclidean(x, xᵢ))
-end
-
-# D² - directional second derivative
-function (op::D²{<:Gaussian})(x, xᵢ)
-    ε2 = op.basis.ε^2
-    φ = exp(-ε2 * sqeuclidean(x, xᵢ))
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, x .- xᵢ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, x .- xᵢ)
-    return (4 * ε2^2 * dot_v1_r * dot_v2_r - 2 * ε2 * dot_v1_v2) * φ
-end
-
 # H - Hessian matrix
 function (op::H{<:Gaussian})(x, xᵢ)
     ε2 = op.basis.ε^2

--- a/src/basis/inverse_multiquadric.jl
+++ b/src/basis/inverse_multiquadric.jl
@@ -42,24 +42,6 @@ function (op::∇{<:IMQ})(x, xᵢ)
     return (xᵢ .- x) * (ε2 / sqrt((ε2 * sqeuclidean(x, xᵢ) + 1)^3))
 end
 
-# D - directional derivative
-function (op::D{<:IMQ})(x, xᵢ)
-    ε2 = op.basis.ε^2
-    return LinearAlgebra.dot(op.v, xᵢ .- x) * (ε2 / sqrt((ε2 * sqeuclidean(x, xᵢ) + 1)^3))
-end
-
-# D² - directional second derivative
-function (op::D²{<:IMQ})(x, xᵢ)
-    ε2 = op.basis.ε^2
-    ε4 = ε2^2
-    Δ = x .- xᵢ
-    s = ε2 * sqeuclidean(x, xᵢ) + 1
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, Δ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, Δ)
-    return 3 * ε4 * dot_v1_r * dot_v2_r / sqrt(s^5) - ε2 * dot_v1_v2 / sqrt(s^3)
-end
-
 # H - Hessian matrix
 function (op::H{<:IMQ})(x, xᵢ)
     ε2 = op.basis.ε^2

--- a/src/basis/polyharmonic_spline.jl
+++ b/src/basis/polyharmonic_spline.jl
@@ -75,21 +75,6 @@ function (op::∇{<:PHS1})(x, xᵢ, normal)
     return -normal / (r + AVOID_INF) + dot_normal * (x .- xᵢ) / (r^3 + AVOID_INF)
 end
 
-# D - directional derivative
-function (op::D{<:PHS1})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    return LinearAlgebra.dot(op.v, x .- xᵢ) / (r + AVOID_INF)
-end
-
-# D² - directional second derivative
-function (op::D²{<:PHS1})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, x .- xᵢ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, x .- xᵢ)
-    return dot_v1_v2 / (r + AVOID_INF) - (dot_v1_r * dot_v2_r) / (r^3 + AVOID_INF)
-end
-
 # H - Hessian matrix
 function (op::H{<:PHS1})(x, xᵢ)
     r = euclidean(x, xᵢ)
@@ -174,21 +159,6 @@ function (op::∇{<:PHS3})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
     return -3 * (normal * r + dot_normal * (x .- xᵢ) / (r + AVOID_INF))
-end
-
-# D - directional derivative
-function (op::D{<:PHS3})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    return 3 * LinearAlgebra.dot(op.v, x .- xᵢ) * r
-end
-
-# D² - directional second derivative
-function (op::D²{<:PHS3})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, x .- xᵢ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, x .- xᵢ)
-    return 3 * (dot_v1_v2 * r + dot_v1_r * dot_v2_r / (r + AVOID_INF))
 end
 
 # H - Hessian matrix
@@ -277,21 +247,6 @@ function (op::∇{<:PHS5})(x, xᵢ, normal)
     return -5 * (normal * r^3 + 3 * dot_normal * (x .- xᵢ) * r)
 end
 
-# D - directional derivative
-function (op::D{<:PHS5})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    return 5 * LinearAlgebra.dot(op.v, x .- xᵢ) * r^3
-end
-
-# D² - directional second derivative
-function (op::D²{<:PHS5})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, x .- xᵢ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, x .- xᵢ)
-    return 5 * (dot_v1_v2 * r^3 + 3 * dot_v1_r * dot_v2_r * r)
-end
-
 # H - Hessian matrix
 function (op::H{<:PHS5})(x, xᵢ)
     r = euclidean(x, xᵢ)
@@ -376,21 +331,6 @@ function (op::∇{<:PHS7})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
     return -7 * (normal * r^5 + 5 * dot_normal * (x .- xᵢ) * r^3)
-end
-
-# D - directional derivative
-function (op::D{<:PHS7})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    return 7 * LinearAlgebra.dot(op.v, x .- xᵢ) * r^5
-end
-
-# D² - directional second derivative
-function (op::D²{<:PHS7})(x, xᵢ)
-    r = euclidean(x, xᵢ)
-    dot_v1_v2 = LinearAlgebra.dot(op.v1, op.v2)
-    dot_v1_r = LinearAlgebra.dot(op.v1, x .- xᵢ)
-    dot_v2_r = LinearAlgebra.dot(op.v2, x .- xᵢ)
-    return 7 * (dot_v1_v2 * r^5 + 5 * dot_v1_r * dot_v2_r * r^3)
 end
 
 # H - Hessian matrix

--- a/src/operators/monomial/partial.jl
+++ b/src/operators/monomial/partial.jl
@@ -324,7 +324,6 @@ end
 function ∂²(::MonomialBasis{3, 2}, ::Val{3})
     function basis!(b, x)
         T = eltype(x)
-        T = eltype(x)
         b[1] = zero(T)
         b[2] = zero(T)
         b[3] = zero(T)

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -54,13 +54,13 @@ eigenvalue problems.
 is_self_adjoint(::AbstractOperator) = false
 is_self_adjoint(::Laplacian) = true
 is_self_adjoint(::Identity) = true
-is_self_adjoint(::Regrid) = false
 
 """
-    derivative_order(op) -> Int
+    derivative_order(op) -> Union{Int, Missing}
 
 Total order of differentiation. Useful for estimating required polynomial degree
-and stencil size.
+and stencil size. Returns `missing` for `Custom` operators, whose derivative
+order cannot be inferred from the wrapped function.
 """
 derivative_order(::Identity) = 0
 derivative_order(::Regrid) = 0
@@ -75,6 +75,4 @@ derivative_order(::Curl) = 1
 derivative_order(::StrainRate) = 1
 derivative_order(::RotationRate) = 1
 derivative_order(s::ScaledOperator) = derivative_order(s.op)
-function derivative_order(::Custom)
-    throw(ArgumentError("derivative_order is not defined for Custom operators"))
-end
+derivative_order(::Custom) = missing

--- a/src/solve/assembly.jl
+++ b/src/solve/assembly.jl
@@ -178,35 +178,14 @@ end
 # ============================================================================
 
 """
-    _build_stencil!(A, b, ℒrbf, ℒmon, data, eval_point, basis, mon, k)
-
-Assemble complete stencil: build collocation matrix, build RHS, solve for weights.
-Works for both interior stencils (AbstractVector) and Hermite stencils (HermiteStencilData)
-via dispatch helpers in `_build_collocation_matrix!` and `_build_rhs!`.
-
-Returns: weights (first k rows of solution, size k×num_ops)
-"""
-function _build_stencil!(
-        A,
-        b,
-        ℒrbf,
-        ℒmon,
-        data,
-        eval_point,
-        basis::AbstractRadialBasis,
-        mon::MonomialBasis,
-        k::Int,
-    )
-    _build_collocation_matrix!(A, data, basis, mon, k)
-    _build_rhs!(b, ℒrbf, ℒmon, data, eval_point, basis, mon, k)
-    return (A \ b)[1:k, :]
-end
-
-"""
     _build_stencil!(λ, A, b, ℒrbf, ℒmon, data, eval_point, basis, mon, k)
 
-In-place variant: writes solution into pre-allocated `λ` buffer, returns view of first k rows.
-Avoids allocating the solution vector and the slice on every call.
+Assemble complete stencil: build collocation matrix, build RHS, solve for weights
+in the pre-allocated `λ` buffer. Works for both interior stencils (AbstractVector)
+and Hermite stencils (HermiteStencilData) via dispatch helpers in
+`_build_collocation_matrix!` and `_build_rhs!`.
+
+Returns: view of the first k rows of `λ` (size k×num_ops).
 """
 function _build_stencil!(
         λ,
@@ -229,11 +208,6 @@ end
 # CPU: Symmetric → bunchkaufman (optimal for symmetric indefinite)
 function _solve_system!(λ, A::Symmetric, b)
     return ldiv!(λ, bunchkaufman!(A, true), b)
-end
-
-# Generic fallback: uses \ which dispatches to cuSOLVER on GPU, LAPACK on CPU
-function _solve_system!(λ, A::AbstractMatrix, b)
-    return λ .= A \ b
 end
 
 # Dispatch helpers: Vector gets 1D view, Matrix gets 2D slice view

--- a/test/basis/basis.jl
+++ b/test/basis/basis.jl
@@ -1,11 +1,6 @@
 using RadialBasisFunctions
 import RadialBasisFunctions as RBF
 
-@testset "Pretty Printing" begin
-    superscripts = ("", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹")
-    @test all(RBF.unicode_order.(Val.(1:9)) .== superscripts)
-end
-
 @testset "Basis - General Utils" begin
     m = MonomialBasis(2, 3)
     @test dim(m) == 2

--- a/test/basis/gaussian.jl
+++ b/test/basis/gaussian.jl
@@ -42,59 +42,12 @@ end
     @test ∂²rbf(x₁, x₂) ≈ 56 / exp(20)
 end
 
-@testset "Directional First Derivatives" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
-    # Test D equals dot(v, ∇)
-    @test RBF.D(g, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(g)(x₁, x₂))
-    @test RBF.D(g, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(g)(x₁, x₂))
-    @test RBF.D(g, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(g)(x₁, x₂))
-
-    # Test against ForwardDiff
-    expected = FD.gradient(x -> g(x, x₂), x₁) ⋅ normal
-    @test RBF.D(g, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-end
-
-@testset "Directional Second Derivatives" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
-    # Same direction test
-    dir_deriv = RBF.D²(g, normal, normal)
-
-    # Calculate expected value using Hessian (D² computes v1' * H * v2)
-    H_fd = FD.hessian(x -> g(x, x₂), x₁)
-    second_normal = dot(normal, H_fd * normal)
-
-    @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-    # Test with orthogonal directions
-    dir_deriv_xy = RBF.D²(g, v1, v2)
-
-    # Calculate mixed directional derivative using Hessian
-    second_mixed = dot(v1, H_fd * v2)
-
-    @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-end
-
 @testset "Hessian" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
     Hrbf = RBF.H(g)
     H_val = Hrbf(x₁, x₂)
 
     # Test matrix size
     @test size(H_val) == (2, 2)
-
-    # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-    @test dot(v1, H_val * v2) ≈ RBF.D²(g, v1, v2)(x₁, x₂) rtol = 1.0e-10
-    @test dot(v2, H_val * v1) ≈ RBF.D²(g, v2, v1)(x₁, x₂) rtol = 1.0e-10
-    @test dot(normal, H_val * normal) ≈ RBF.D²(g, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
     # Test Hessian symmetry
     @test H_val ≈ H_val' rtol = 1.0e-10

--- a/test/basis/inverse_multiquadric.jl
+++ b/test/basis/inverse_multiquadric.jl
@@ -42,59 +42,12 @@ end
     @test ∂²rbf(x₁, x₂) ≈ -4 / (49 * sqrt(21))
 end
 
-@testset "Directional First Derivatives" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
-    # Test D equals dot(v, ∇)
-    @test RBF.D(imq, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(imq)(x₁, x₂))
-    @test RBF.D(imq, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(imq)(x₁, x₂))
-    @test RBF.D(imq, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(imq)(x₁, x₂))
-
-    # Test against ForwardDiff
-    expected = FD.gradient(x -> imq(x, x₂), x₁) ⋅ normal
-    @test RBF.D(imq, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-end
-
-@testset "Directional Second Derivatives" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
-    # Same direction test
-    dir_deriv = RBF.D²(imq, normal, normal)
-
-    # Calculate expected value using Hessian (D² computes v1' * H * v2)
-    H_fd = FD.hessian(x -> imq(x, x₂), x₁)
-    second_normal = dot(normal, H_fd * normal)
-
-    @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-    # Test with orthogonal directions
-    dir_deriv_xy = RBF.D²(imq, v1, v2)
-
-    # Calculate mixed directional derivative using Hessian
-    second_mixed = dot(v1, H_fd * v2)
-
-    @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-end
-
 @testset "Hessian" begin
-    v1 = SVector(1.0, 0.0)
-    v2 = SVector(0.0, 1.0)
-    normal = SVector(1.0, 1) ./ sqrt(2)
-
     Hrbf = RBF.H(imq)
     H_val = Hrbf(x₁, x₂)
 
     # Test matrix size
     @test size(H_val) == (2, 2)
-
-    # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-    @test dot(v1, H_val * v2) ≈ RBF.D²(imq, v1, v2)(x₁, x₂) rtol = 1.0e-10
-    @test dot(v2, H_val * v1) ≈ RBF.D²(imq, v2, v1)(x₁, x₂) rtol = 1.0e-10
-    @test dot(normal, H_val * normal) ≈ RBF.D²(imq, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
     # Test Hessian symmetry
     @test H_val ≈ H_val' rtol = 1.0e-10

--- a/test/basis/polyharmonic_spline.jl
+++ b/test/basis/polyharmonic_spline.jl
@@ -71,60 +71,12 @@ end
         @test ∇²rbf(x₁, x₂, normal) ≈ (FD.gradient(x_2 -> ∇²rbf(x₁, x_2), x₂) ⋅ normal)
     end
 
-    @testset "Directional First Derivatives" begin
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Test D equals dot(v, ∇)
-        @test RBF.D(phs, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(phs)(x₁, x₂))
-
-        # Test against ForwardDiff
-        expected = FD.gradient(x -> phs(x, x₂), x₁) ⋅ normal
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-    end
-
-    @testset "Directional Second Derivatives" begin
-        # Define two direction vectors
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Same direction test (both normal)
-        dir_deriv = RBF.D²(phs, normal, normal)
-
-        # Calculate expected value using Hessian (D² computes v1' * H * v2)
-        H_fd = FD.hessian(x -> phs(x, x₂), x₁)
-        second_normal = dot(normal, H_fd * normal)
-
-        @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-        # Test with orthogonal directions
-        dir_deriv_xy = RBF.D²(phs, v1, v2)
-
-        # Calculate mixed directional derivative using Hessian
-        second_mixed = dot(v1, H_fd * v2)
-
-        @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-    end
-
     @testset "Hessian" begin
-        v1 = SVector(1.0, 0.0)
-        v2 = SVector(0.0, 1.0)
-        normal = SVector(1.0, 1) ./ sqrt(2)
-
         Hrbf = RBF.H(phs)
         H_val = Hrbf(x₁, x₂)
 
         # Test matrix size
         @test size(H_val) == (2, 2)
-
-        # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-        @test dot(v1, H_val * v2) ≈ RBF.D²(phs, v1, v2)(x₁, x₂) rtol = 1.0e-10
-        @test dot(v2, H_val * v1) ≈ RBF.D²(phs, v2, v1)(x₁, x₂) rtol = 1.0e-10
-        @test dot(normal, H_val * normal) ≈ RBF.D²(phs, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
         # Test Hessian symmetry
         @test H_val ≈ H_val' rtol = 1.0e-10
@@ -186,60 +138,12 @@ end
         @test ∇²rbf(x₁, x₂, normal) ≈ (FD.gradient(x_2 -> ∇²rbf(x₁, x_2), x₂) ⋅ normal)
     end
 
-    @testset "Directional First Derivatives" begin
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Test D equals dot(v, ∇)
-        @test RBF.D(phs, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(phs)(x₁, x₂))
-
-        # Test against ForwardDiff
-        expected = FD.gradient(x -> phs(x, x₂), x₁) ⋅ normal
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-    end
-
-    @testset "Directional Second Derivatives" begin
-        # Define two direction vectors
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Same direction test (both normal)
-        dir_deriv = RBF.D²(phs, normal, normal)
-
-        # Calculate expected value using Hessian (D² computes v1' * H * v2)
-        H_fd = FD.hessian(x -> phs(x, x₂), x₁)
-        second_normal = dot(normal, H_fd * normal)
-
-        @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-        # Test with orthogonal directions
-        dir_deriv_xy = RBF.D²(phs, v1, v2)
-
-        # Calculate mixed directional derivative using Hessian
-        second_mixed = dot(v1, H_fd * v2)
-
-        @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-    end
-
     @testset "Hessian" begin
-        v1 = SVector(1.0, 0.0)
-        v2 = SVector(0.0, 1.0)
-        normal = SVector(1.0, 1) ./ sqrt(2)
-
         Hrbf = RBF.H(phs)
         H_val = Hrbf(x₁, x₂)
 
         # Test matrix size
         @test size(H_val) == (2, 2)
-
-        # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-        @test dot(v1, H_val * v2) ≈ RBF.D²(phs, v1, v2)(x₁, x₂) rtol = 1.0e-10
-        @test dot(v2, H_val * v1) ≈ RBF.D²(phs, v2, v1)(x₁, x₂) rtol = 1.0e-10
-        @test dot(normal, H_val * normal) ≈ RBF.D²(phs, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
         # Test Hessian symmetry
         @test H_val ≈ H_val' rtol = 1.0e-10
@@ -301,60 +205,12 @@ end
         @test ∇²rbf(x₁, x₂, normal) ≈ (FD.gradient(x_2 -> ∇²rbf(x₁, x_2), x₂) ⋅ normal)
     end
 
-    @testset "Directional First Derivatives" begin
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Test D equals dot(v, ∇)
-        @test RBF.D(phs, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(phs)(x₁, x₂))
-
-        # Test against ForwardDiff
-        expected = FD.gradient(x -> phs(x, x₂), x₁) ⋅ normal
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-    end
-
-    @testset "Directional Second Derivatives" begin
-        # Define two direction vectors
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Same direction test (both normal)
-        dir_deriv = RBF.D²(phs, normal, normal)
-
-        # Calculate expected value using Hessian (D² computes v1' * H * v2)
-        H_fd = FD.hessian(x -> phs(x, x₂), x₁)
-        second_normal = dot(normal, H_fd * normal)
-
-        @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-        # Test with orthogonal directions
-        dir_deriv_xy = RBF.D²(phs, v1, v2)
-
-        # Calculate mixed directional derivative using Hessian
-        second_mixed = dot(v1, H_fd * v2)
-
-        @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-    end
-
     @testset "Hessian" begin
-        v1 = SVector(1.0, 0.0)
-        v2 = SVector(0.0, 1.0)
-        normal = SVector(1.0, 1) ./ sqrt(2)
-
         Hrbf = RBF.H(phs)
         H_val = Hrbf(x₁, x₂)
 
         # Test matrix size
         @test size(H_val) == (2, 2)
-
-        # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-        @test dot(v1, H_val * v2) ≈ RBF.D²(phs, v1, v2)(x₁, x₂) rtol = 1.0e-10
-        @test dot(v2, H_val * v1) ≈ RBF.D²(phs, v2, v1)(x₁, x₂) rtol = 1.0e-10
-        @test dot(normal, H_val * normal) ≈ RBF.D²(phs, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
         # Test Hessian symmetry
         @test H_val ≈ H_val' rtol = 1.0e-10
@@ -415,60 +271,12 @@ end
         @test ∇²rbf(x₁, x₂, normal) ≈ (FD.gradient(x_2 -> ∇²rbf(x₁, x_2), x₂) ⋅ normal)
     end
 
-    @testset "Directional First Derivatives" begin
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Test D equals dot(v, ∇)
-        @test RBF.D(phs, v1)(x₁, x₂) ≈ dot(v1, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, v2)(x₁, x₂) ≈ dot(v2, RBF.∇(phs)(x₁, x₂))
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ dot(normal, RBF.∇(phs)(x₁, x₂))
-
-        # Test against ForwardDiff
-        expected = FD.gradient(x -> phs(x, x₂), x₁) ⋅ normal
-        @test RBF.D(phs, normal)(x₁, x₂) ≈ expected rtol = 1.0e-5
-    end
-
-    @testset "Directional Second Derivatives" begin
-        # Define two direction vectors
-        v1 = SVector(1.0, 0.0)  # x direction
-        v2 = SVector(0.0, 1.0)  # y direction
-        normal = SVector(1.0, 1) ./ sqrt(2)  # Normalized diagonal direction
-
-        # Same direction test (both normal)
-        dir_deriv = RBF.D²(phs, normal, normal)
-
-        # Calculate expected value using Hessian (D² computes v1' * H * v2)
-        H_fd = FD.hessian(x -> phs(x, x₂), x₁)
-        second_normal = dot(normal, H_fd * normal)
-
-        @test dir_deriv(x₁, x₂) ≈ second_normal rtol = 1.0e-5
-
-        # Test with orthogonal directions
-        dir_deriv_xy = RBF.D²(phs, v1, v2)
-
-        # Calculate mixed directional derivative using Hessian
-        second_mixed = dot(v1, H_fd * v2)
-
-        @test dir_deriv_xy(x₁, x₂) ≈ second_mixed rtol = 1.0e-5
-    end
-
     @testset "Hessian" begin
-        v1 = SVector(1.0, 0.0)
-        v2 = SVector(0.0, 1.0)
-        normal = SVector(1.0, 1) ./ sqrt(2)
-
         Hrbf = RBF.H(phs)
         H_val = Hrbf(x₁, x₂)
 
         # Test matrix size
         @test size(H_val) == (2, 2)
-
-        # Test consistency with D²: dot(v1, H * v2) should equal D²(basis, v1, v2)
-        @test dot(v1, H_val * v2) ≈ RBF.D²(phs, v1, v2)(x₁, x₂) rtol = 1.0e-10
-        @test dot(v2, H_val * v1) ≈ RBF.D²(phs, v2, v1)(x₁, x₂) rtol = 1.0e-10
-        @test dot(normal, H_val * normal) ≈ RBF.D²(phs, normal, normal)(x₁, x₂) rtol = 1.0e-10
 
         # Test Hessian symmetry
         @test H_val ≈ H_val' rtol = 1.0e-10

--- a/test/operators/device_kwarg.jl
+++ b/test/operators/device_kwarg.jl
@@ -122,12 +122,6 @@ end
     λ_sym = similar(b_vec)
     RBF._solve_system!(λ_sym, A_sym, copy(b_vec))
     @test λ_sym ≈ λ_ref
-
-    # _solve_system! generic fallback (AbstractMatrix)
-    A_plain = copy(A_data)
-    λ_gen = similar(b_vec)
-    RBF._solve_system!(λ_gen, A_plain, copy(b_vec))
-    @test λ_gen ≈ λ_ref atol = 1.0e-10
 end
 
 @testset "_solve_system! with matrix RHS" begin
@@ -147,12 +141,6 @@ end
     λ_sym = similar(B_mat)
     RBF._solve_system!(λ_sym, A_sym, copy(B_mat))
     @test λ_sym ≈ λ_ref
-
-    # Generic path
-    A_plain = copy(A_data)
-    λ_gen = similar(B_mat)
-    RBF._solve_system!(λ_gen, A_plain, copy(B_mat))
-    @test λ_gen ≈ λ_ref atol = 1.0e-10
 end
 
 @testset "Adapt.adapt_structure for RadialBasisOperator" begin

--- a/test/operators/operator_traits.jl
+++ b/test/operators/operator_traits.jl
@@ -66,5 +66,5 @@ end
     @test derivative_order(StrainRate{2}()) == 1
     @test derivative_order(RotationRate{3}()) == 1
     @test derivative_order(2.0 * Laplacian()) == 2
-    @test_throws ArgumentError derivative_order(Custom{0}(identity))
+    @test derivative_order(Custom{0}(identity)) === missing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,3 +153,9 @@ if Base.find_package("Mooncake") !== nothing
         include("extensions/mooncake_ext.jl")
     end
 end
+
+if Base.find_package("Enzyme") !== nothing
+    @safetestset "Enzyme Extension" begin
+        include("extensions/enzyme_ext.jl")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,6 +123,7 @@ end
 @safetestset "Solve Tests" begin
     include("solve/collocation_matrix.jl")
     include("solve/rhs_vector.jl")
+    include("solve/hermite_stencil.jl")
 end
 
 @safetestset "Solve Integration Tests" begin

--- a/test/solve/hermite_stencil.jl
+++ b/test/solve/hermite_stencil.jl
@@ -23,17 +23,16 @@ import RadialBasisFunctions as RBF
         k = 3
         nmon = 2  # 1D linear: [1, x]
         n = k + nmon
+        λ_std = zeros(Float64, n, 1)
         A_std = Symmetric(zeros(Float64, n, n), :U)
         b_std = zeros(Float64, n, 1)
 
-        # Create identity operator (interpolation)
-        identity_op = x -> x
         ℒrbf(x1, x2) = basis(x1, x2)  # Identity on RBF
         ℒmon(arr, x) = mon(arr, x)     # Identity on monomial
 
         # Test standard path - use plain data array
         weights_std = RBF._build_stencil!(
-            A_std, b_std, ℒrbf, ℒmon, data, eval_point, basis, mon, k
+            λ_std, A_std, b_std, ℒrbf, ℒmon, data, eval_point, basis, mon, k
         )
 
         @test size(weights_std) == (k, 1)

--- a/test/solve/hermite_stencil.jl
+++ b/test/solve/hermite_stencil.jl
@@ -23,9 +23,10 @@ import RadialBasisFunctions as RBF
         k = 3
         nmon = 2  # 1D linear: [1, x]
         n = k + nmon
-        λ_std = zeros(Float64, n, 1)
+        # Single (non-tuple) operators pair with Vector buffers, matching _prepare_buffer
+        λ_std = zeros(Float64, n)
         A_std = Symmetric(zeros(Float64, n, n), :U)
-        b_std = zeros(Float64, n, 1)
+        b_std = zeros(Float64, n)
 
         ℒrbf(x1, x2) = basis(x1, x2)  # Identity on RBF
         ℒmon(arr, x) = mon(arr, x)     # Identity on monomial
@@ -35,7 +36,7 @@ import RadialBasisFunctions as RBF
             λ_std, A_std, b_std, ℒrbf, ℒmon, data, eval_point, basis, mon, k
         )
 
-        @test size(weights_std) == (k, 1)
+        @test size(weights_std) == (k,)
         @test all(isfinite.(weights_std))
     end
 
@@ -57,9 +58,10 @@ import RadialBasisFunctions as RBF
             [1.0],    # Outward normal for boundary point 3 (rightward)
         ]
 
-        # Create HermiteStencilData
+        # Create HermiteStencilData with a workspace sized for the monomial basis
+        # (Neumann collocation entries write ∂ₙ of the monomials into it)
         hermite_data = RBF.HermiteStencilData(
-            data, is_boundary, boundary_conditions, normals
+            data, is_boundary, boundary_conditions, normals, zeros(nmon)
         )
 
         # Test collocation matrix


### PR DESCRIPTION
Second PR of the systematic-review roadmap (follows #137). Pure-win cleanup: no behavior changes, net −480 lines.

## Dead code removed
- **`D`/`D²` directional-derivative functors** — unexported and unused in production (both structs + 12 basis-specific methods + their unit tests). The `Directional` operator contracts Jacobian weights instead.
- **Non-in-place 9-arg `_build_stencil!`** — its only caller was a test file that was never included by `runtests.jl` (see below).
- **`_solve_system!(λ, A::AbstractMatrix, b)` fallback** — unreachable: the sole caller always passes a `Symmetric`, which dispatches to the bunchkaufman method.
- **`unicode_order`** — only referenced by its own test.

## Dependencies
- Removed **ChunkSplitters** (loaded, never used) and **StaticArrays** — `src/` was already fully on StaticArraysCore; only the Mooncake extension's `SVector` import needed switching.
- Added missing compat bounds: `Random = "1"`, `SparseArrays = "1"`.

## Test infrastructure
- **Wired `test/extensions/enzyme_ext.jl` into `runtests.jl`** (gate mirrors the Mooncake block; the file self-skips its testsets on Julia ≥ 1.12 per EnzymeAD/Enzyme.jl#2699).
- **Wired `test/solve/hermite_stencil.jl` into the Solve Tests group** — it had never run. Doing so surfaced two construction bugs it accumulated while dormant (Matrix RHS paired with non-tuple operators; zero-length `poly_workspace` overflowing on Neumann collocation), both repaired, and its dead 9-arg `_build_stencil!` call migrated to the live in-place variant.

## Traits & micro-cleanups
- Dropped redundant `is_self_adjoint(::Regrid) = false` (fallback already returns `false`).
- `derivative_order(::Custom)` now returns `missing` instead of throwing — the order is unknowable, not an argument error, and `missing` composes cleanly with the operator-algebra work coming later in the roadmap. Docstring updated to `Union{Int, Missing}`.
- Removed a duplicated `T = eltype(x)` line; gitignored `*sync-conflict*` files.

Full local suite: **1583 passed, 0 failed, 1 skipped** (the intentional Enzyme self-skip on Julia 1.12).

---
<sub>🤖 Drafted by Claude, who deleted 480 lines and would like that reflected in its performance review.</sub>