### PR TITLE
perf(solve): eliminate hot-loop allocations in weight building

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -43,6 +43,37 @@ SUITE["Directional (per point)"] = let s = BenchmarkGroup()
     s["eval"] = @benchmarkable ∇v($y)
 end
 
+# 2D unit square with mixed BCs: Dirichlet on x=0/x=1, Neumann on y=0/y=1.
+# Each edge owns one corner so boundary membership is exact and duplicate-free.
+n_edge = 25
+t_edge = range(0, 1; length = n_edge + 1)
+left = [SVector(0.0, t) for t in t_edge[2:end]]
+right = [SVector(1.0, t) for t in t_edge[1:(end - 1)]]
+bottom = [SVector(t, 0.0) for t in t_edge[1:(end - 1)]]
+top = [SVector(t, 1.0) for t in t_edge[2:end]]
+boundary = vcat(left, right, bottom, top)
+interior = SVector{2}.(HaltonPoint(2)[1:900])
+xh = vcat(boundary, interior)
+hermite = (
+    is_boundary = vcat(fill(true, length(boundary)), fill(false, length(interior))),
+    bc = vcat(fill(Dirichlet(), 2 * n_edge), fill(Neumann(), 2 * n_edge)),
+    normals = vcat(
+        fill(SVector(-1.0, 0.0), n_edge),
+        fill(SVector(1.0, 0.0), n_edge),
+        fill(SVector(0.0, -1.0), n_edge),
+        fill(SVector(0.0, 1.0), n_edge),
+    ),
+)
+adjl_h = find_neighbors(xh, 25)
+SUITE["Hermite"]["build weights"] = @benchmarkable laplacian(
+    $xh; basis = $basis, adjl = $adjl_h, hermite = $hermite
+)
+
+xi = SVector{2}.(HaltonPoint(2)[1:500])
+itp = Interpolator(xi, f.(xi), basis)
+xe = SVector{2}.(HaltonPoint(2)[501:600])
+SUITE["Interpolator"]["eval (poly)"] = @benchmarkable itp($xe)
+
 x1 = SVector{3}(rand(3))
 x2 = SVector{3}(rand(3))
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,12 +17,14 @@ basis = PHS(3; poly_deg = 2)
 SUITE["Partial"] = let s = BenchmarkGroup()
     s["build weights"] = @benchmarkable update_weights!($∂x)
     s["eval"] = @benchmarkable ∂x($y)
+    s
 end
 
 grad = gradient(x, basis)
 SUITE["Gradient"] = let s = BenchmarkGroup()
     s["build weights"] = @benchmarkable update_weights!($grad)
     s["eval"] = @benchmarkable grad($y)
+    s
 end
 
 v = SVector(2.0, 1.0, 0.5)
@@ -31,6 +33,7 @@ v /= norm(v)
 SUITE["Directional"] = let s = BenchmarkGroup()
     s["build weights"] = @benchmarkable update_weights!($∇v)
     s["eval"] = @benchmarkable ∇v($y)
+    s
 end
 
 v = map(1:length(x)) do i
@@ -41,6 +44,7 @@ end
 SUITE["Directional (per point)"] = let s = BenchmarkGroup()
     s["build weights"] = @benchmarkable update_weights!($∇v)
     s["eval"] = @benchmarkable ∇v($y)
+    s
 end
 
 # 2D unit square with mixed BCs: Dirichlet on x=0/x=1, Neumann on y=0/y=1.

--- a/src/basis/monomial.jl
+++ b/src/basis/monomial.jl
@@ -103,13 +103,21 @@ function _get_monomial_basis(::Val{Dim}, ::Val{Deg}) where {Dim, Deg}
     return build_monomial_basis(ids)
 end
 
+# scalar loop: `b[ids[i][k]] *= x[i]` materializes a temporary array per index list
+function _monomial_products!(b, ids, x)
+    @inbounds for i in eachindex(ids)
+        xᵢ = x[i]
+        for id in ids[i], j in id
+            b[j] *= xᵢ
+        end
+    end
+    return nothing
+end
+
 function build_monomial_basis(ids::Vector{Vector{Vector{T}}}) where {T <: Int}
     function basis!(b::AbstractVector{B}, x::AbstractVector) where {B}
         b .= one(B)
-        # TODO flatten loop - why does it allocate here
-        @views @inbounds for i in eachindex(ids), k in eachindex(ids[i])
-            b[ids[i][k]] *= x[i]
-        end
+        _monomial_products!(b, ids, x)
         return nothing
     end
     return basis!

--- a/src/operators/monomial/monomial.jl
+++ b/src/operators/monomial/monomial.jl
@@ -98,10 +98,7 @@ end
 function build_monomial_basis(ids::Vector{Vector{Vector{T}}}, c::Vector{T}) where {T <: Int}
     function basis!(db::AbstractVector{B}, x::AbstractVector) where {B}
         db .= one(eltype(x))
-        # TODO optimize - allocations
-        @views @inbounds for i in eachindex(ids), j in eachindex(ids[i])
-            db[ids[i][j]] *= x[i]
-        end
+        _monomial_products!(db, ids, x)
         db .*= c
         return nothing
     end

--- a/src/operators/monomial/partial.jl
+++ b/src/operators/monomial/partial.jl
@@ -339,32 +339,44 @@ function ∂²(::MonomialBasis{3, 2}, ::Val{3})
     return ℒMonomialBasis(3, 2, basis!)
 end
 
-# Add normal derivative functionality
-function ∂_normal(mb::MonomialBasis{Dim, Deg}, normal::AbstractVector) where {Dim, Deg}
-    function basis!(b, x)
-        T = eltype(x)
+"""
+    ∂_normal!(b, scratch, mb, normal, x)
 
-        for i in eachindex(b)
-            b[i] = zero(T)
-        end
+In-place normal derivative of the monomial basis: `b = Σ_d normal[d] * ∂_d P(x)`.
+`scratch` must have the same length as `b`.
+"""
+function ∂_normal!(
+        b::AbstractVector,
+        scratch::AbstractVector,
+        mb::MonomialBasis{Dim, Deg},
+        normal::AbstractVector,
+        x,
+    ) where {Dim, Deg}
+    T = eltype(x)
+    for i in eachindex(b)
+        b[i] = zero(T)
+    end
 
-        tmp = zeros(T, length(b)) #allocating (TODO: optimize)
-        for d in 1:Dim
-            if !iszero(normal[d])
-                # Get the partial derivative operator
-                op = ∂(mb, d)
-
-                # Apply partial derivative
-                fill!(tmp, zero(T))
-                op.f(tmp, x)
-
-                # Add scaled contribution to result
-                for i in eachindex(b)
-                    b[i] += normal[d] * tmp[i]
-                end
+    # Unrolled over dimensions so ∂(mb, Val(d)) is constructed type-stably
+    ntuple(Val(Dim)) do d
+        if !iszero(normal[d])
+            fill!(scratch, zero(T))
+            ∂(mb, Val(d)).f(scratch, x)
+            for i in eachindex(b)
+                b[i] += normal[d] * scratch[i]
             end
         end
+        return nothing
+    end
 
+    return nothing
+end
+
+# Allocating functor form (test/utility use; the solve hot path calls ∂_normal!)
+function ∂_normal(mb::MonomialBasis{Dim, Deg}, normal::AbstractVector) where {Dim, Deg}
+    function basis!(b, x)
+        scratch = zeros(eltype(x), length(b))
+        ∂_normal!(b, scratch, mb, normal, x)
         return nothing
     end
 

--- a/src/solve/assembly.jl
+++ b/src/solve/assembly.jl
@@ -54,6 +54,7 @@ function _mono_rhs!(bmono, ℒmon, mon, eval_point, data::HermiteStencilData, k)
         data.boundary_conditions[eval_idx],
         data.normals[eval_idx],
         data.poly_workspace,
+        data.normal_workspace,
     )
 end
 
@@ -374,7 +375,7 @@ function hermite_poly_dispatch!(
     mon(a, xi)
 
     # Compute ∂ₙP(xi) into workspace
-    ∂_normal(mon, ni)(workspace, xi)
+    ∂_normal!(workspace, data.normal_workspace, mon, ni, xi)
 
     # Combine: a = α*P + β*∂ₙP
     α_val, β_val = α(bc), β(bc)
@@ -408,7 +409,8 @@ Apply boundary conditions to RBF operator evaluation.
 end
 
 """
-    hermite_mono_rhs!(bmono, ℒmon, mon, eval_point, is_bound, bc, normal, workspace)
+    hermite_mono_rhs!(bmono, ℒmon, mon, eval_point, is_bound, bc, normal,
+                      workspace, normal_workspace)
 
 Apply boundary conditions to monomial operator evaluation.
 Dispatches based on boundary point type for type stability.
@@ -422,10 +424,11 @@ Dispatches based on boundary point type for type stability.
         bc::BoundaryCondition,
         normal,
         workspace::AbstractVector,
+        normal_workspace::AbstractVector,
     )
     pt = point_type(is_bound, bc)
     return hermite_mono_rhs_dispatch!(
-        bmono, pt, ℒmon, mon, eval_point, bc, normal, workspace
+        bmono, pt, ℒmon, mon, eval_point, bc, normal, workspace, normal_workspace
     )
 end
 
@@ -439,6 +442,7 @@ function hermite_mono_rhs_dispatch!(
         bc,
         normal,
         workspace,
+        normal_workspace,
     )
     ℒmon(bmono, eval_point)
     return nothing
@@ -446,13 +450,14 @@ end
 
 # NeumannRobin: α*ℒ(P) + β*ℒ(∂ₙP) using pre-allocated workspace
 function hermite_mono_rhs_dispatch!(
-        bmono, ::NeumannRobinPoint, ℒmon, mon::MonomialBasis, eval_point, bc, normal, workspace
+        bmono, ::NeumannRobinPoint, ℒmon, mon::MonomialBasis, eval_point, bc, normal,
+        workspace, normal_workspace,
     )
     # Compute P(eval_point) into bmono
     mon(bmono, eval_point)
 
     # Compute ∂ₙP(eval_point) into workspace
-    ∂_normal(mon, normal)(workspace, eval_point)
+    ∂_normal!(workspace, normal_workspace, mon, normal, eval_point)
 
     # Combine: bmono = α*P + β*∂ₙP
     α_val, β_val = α(bc), β(bc)

--- a/src/solve/assembly.jl
+++ b/src/solve/assembly.jl
@@ -32,8 +32,18 @@ end
 # Compute monomial RHS - dispatch on data type
 _mono_rhs!(bmono, ℒmon, mon, eval_point, data::AbstractVector, k) = ℒmon(bmono, eval_point)
 function _mono_rhs!(bmono, ℒmon, mon, eval_point, data::HermiteStencilData, k)
-    eval_idx = findfirst(i -> data.data[i] == eval_point, 1:k)
-    @assert eval_idx !== nothing "Evaluation point not found in stencil"
+    eval_idx = data.eval_local_idx[]
+    if eval_idx == 0
+        # Fallback scan for callers that bypass update_hermite_stencil_data!
+        for i in 1:k
+            if data.data[i] == eval_point
+                eval_idx = i
+                break
+            end
+        end
+        eval_idx == 0 &&
+            throw(ArgumentError("evaluation point not found in stencil data"))
+    end
     @assert !is_dirichlet(data.boundary_conditions[eval_idx]) "Dirichlet eval nodes handled at higher level"
     return hermite_mono_rhs!(
         bmono,

--- a/src/solve/execution.jl
+++ b/src/solve/execution.jl
@@ -241,7 +241,7 @@ function launch_kernel!(
                 # Mixed interior/boundary stencil
                 update_hermite_stencil_data!(
                     hermite_data, data, neighbors, is_boundary,
-                    boundary_conditions, normals, global_to_boundary,
+                    boundary_conditions, normals, global_to_boundary, eval_point,
                 )
                 weights = _build_stencil!(
                     λ, A, b, ℒrbf, ℒmon, hermite_data, eval_point, basis, mon, k

--- a/src/solve/execution.jl
+++ b/src/solve/execution.jl
@@ -8,17 +8,19 @@ using LinearAlgebra: Symmetric
 # ============================================================================
 
 """
-    allocate_sparse_arrays(TD, k, N_eval, num_ops, adjl, boundary_data)
+    allocate_sparse_arrays(TD, k, N_eval, num_ops, adjl, boundary_data, global_to_boundary)
 
 Allocate sparse matrix arrays for COO format sparse matrix construction.
 Exactly counts non-zeros: interior points get k entries, Dirichlet points get 1 entry.
 """
 function allocate_sparse_arrays(
-        TD, k::Int, N_eval::Int, num_ops::Int, adjl, boundary_data::BoundaryData
+        TD, k::Int, N_eval::Int, num_ops::Int, adjl, boundary_data::BoundaryData,
+        global_to_boundary::Vector{Int},
     )
     # Count exact non-zeros needed
     total_nnz, row_offsets = count_nonzeros(
-        adjl, boundary_data.is_boundary, boundary_data.boundary_conditions
+        adjl, boundary_data.is_boundary, boundary_data.boundary_conditions,
+        global_to_boundary,
     )
 
     I = Vector{Int}(undef, total_nnz)
@@ -35,11 +37,11 @@ Count exact number of non-zero entries for optimized allocation.
 Returns (total_nnz, row_offsets) where row_offsets[i] is the starting position for row i.
 """
 function count_nonzeros(
-        adjl, is_boundary::Vector{Bool}, boundary_conditions::Vector{<:BoundaryCondition}
+        adjl, is_boundary::Vector{Bool}, boundary_conditions::Vector{<:BoundaryCondition},
+        global_to_boundary::Vector{Int} = construct_global_to_boundary(is_boundary),
     )
     N_eval = length(adjl)
     row_offsets = Vector{Int}(undef, N_eval + 1)
-    global_to_boundary = construct_global_to_boundary(is_boundary)
 
     total_nnz = 0
     row_offsets[1] = 1  # 1-based indexing
@@ -151,9 +153,11 @@ function build_weights_kernel(
     num_ops = _num_ops(ℒrbf)
     N_eval = length(eval_points)
 
+    global_to_boundary = construct_global_to_boundary(boundary_data.is_boundary)
+
     # Allocate sparse arrays
     I, J, V, row_offsets = allocate_sparse_arrays(
-        TD, k, N_eval, num_ops, adjl, boundary_data
+        TD, k, N_eval, num_ops, adjl, boundary_data, global_to_boundary
     )
 
     # Calculate batches
@@ -162,7 +166,7 @@ function build_weights_kernel(
     # Launch kernel
     launch_kernel!(
         I, J, V, data, eval_points, adjl, basis, ℒrbf, ℒmon, mon,
-        boundary_data, row_offsets, batch_size, N_eval, n_batches,
+        boundary_data, global_to_boundary, row_offsets, batch_size, N_eval, n_batches,
         k, nmon, num_ops, device,
     )
 
@@ -181,7 +185,7 @@ Handles Dirichlet/Interior/Hermite stencil classification via dispatch.
 """
 function launch_kernel!(
         I, J, V, data, eval_points, adjl, basis, ℒrbf, ℒmon, mon,
-        boundary_data::BoundaryData, row_offsets,
+        boundary_data::BoundaryData, global_to_boundary, row_offsets,
         batch_size, N_eval, n_batches, k, nmon, num_ops, device,
     )
     TD = eltype(first(data))
@@ -189,7 +193,6 @@ function launch_kernel!(
 
     # Pre-allocate Hermite workspace for each batch (includes polynomial workspace)
     batch_hermite_datas = [HermiteStencilData{TD}(k, dim, nmon) for _ in 1:n_batches]
-    global_to_boundary = construct_global_to_boundary(boundary_data.is_boundary)
 
     @kernel function weight_kernel(
             I, J, V, data, eval_points, adjl, basis, ℒrbf, ℒmon, mon,

--- a/src/solve/types.jl
+++ b/src/solve/types.jl
@@ -174,6 +174,14 @@ struct InteriorStencil <: StencilType end  # All neighbors are interior
 struct DirichletStencil <: StencilType end  # Eval point is Dirichlet BC
 struct HermiteStencil <: StencilType end    # Mixed interior/boundary
 
+"""Early-exit scan; avoids materializing `is_boundary[neighbors]` per stencil."""
+@inline function _any_boundary(is_boundary, neighbors)
+    for n in neighbors
+        is_boundary[n] && return true
+    end
+    return false
+end
+
 """
     classify_stencil(is_boundary, boundary_conditions, eval_idx,
                     neighbors, global_to_boundary)
@@ -187,7 +195,7 @@ function classify_stencil(
         neighbors::Vector{Int},
         global_to_boundary::Vector{Int},
     ) where {T}
-    if sum(is_boundary[neighbors]) == 0
+    if !_any_boundary(is_boundary, neighbors)
         return InteriorStencil()
     elseif is_boundary[eval_idx] &&
             is_dirichlet(boundary_conditions[global_to_boundary[eval_idx]])

--- a/src/solve/types.jl
+++ b/src/solve/types.jl
@@ -56,6 +56,7 @@ Fields:
 - `boundary_conditions`: BC for each point (use Internal() for interior)
 - `normals`: Normal vectors (zero for interior points)
 - `poly_workspace`: Pre-allocated buffer for polynomial operations (avoids allocations in hot path)
+- `normal_workspace`: Pre-allocated scratch for in-place normal-derivative evaluation
 - `eval_local_idx`: Local index of the evaluation point among the stencil points
   (set by `update_hermite_stencil_data!`; 0 when absent/unset)
 
@@ -68,6 +69,7 @@ struct HermiteStencilData{T <: Real}
     boundary_conditions::Vector{BoundaryCondition{T}}
     normals::Vector{Vector{T}}
     poly_workspace::Vector{T}  # Pre-allocated buffer for polynomial operations
+    normal_workspace::Vector{T}  # Scratch for in-place normal-derivative evaluation
     eval_local_idx::Base.RefValue{Int}
 
     function HermiteStencilData(
@@ -99,7 +101,7 @@ struct HermiteStencilData{T <: Real}
 
         return new{T}(
             data_vectors, is_boundary, boundary_conditions, normals_vectors,
-            poly_workspace, Ref(0),
+            poly_workspace, Vector{T}(undef, length(poly_workspace)), Ref(0),
         )
     end
 end

--- a/src/solve/types.jl
+++ b/src/solve/types.jl
@@ -56,16 +56,19 @@ Fields:
 - `boundary_conditions`: BC for each point (use Internal() for interior)
 - `normals`: Normal vectors (zero for interior points)
 - `poly_workspace`: Pre-allocated buffer for polynomial operations (avoids allocations in hot path)
+- `eval_local_idx`: Local index of the evaluation point among the stencil points
+  (set by `update_hermite_stencil_data!`; 0 when absent/unset)
 
 Note: For interior points (is_boundary[i] == false), boundary_conditions[i]
 and normals[i] contain sentinel values and should not be accessed.
 """
 struct HermiteStencilData{T <: Real}
-    data::AbstractVector{Vector{T}}
+    data::Vector{Vector{T}}
     is_boundary::Vector{Bool}
     boundary_conditions::Vector{BoundaryCondition{T}}
     normals::Vector{Vector{T}}
     poly_workspace::Vector{T}  # Pre-allocated buffer for polynomial operations
+    eval_local_idx::Base.RefValue{Int}
 
     function HermiteStencilData(
             data::AbstractVector{<:AbstractVector{T}},
@@ -95,7 +98,8 @@ struct HermiteStencilData{T <: Real}
         normals_vectors = [Vector{T}(normal) for normal in normals]
 
         return new{T}(
-            data_vectors, is_boundary, boundary_conditions, normals_vectors, poly_workspace
+            data_vectors, is_boundary, boundary_conditions, normals_vectors,
+            poly_workspace, Ref(0),
         )
     end
 end
@@ -115,10 +119,14 @@ end
 """
     update_hermite_stencil_data!(hermite_data, global_data, neighbors,
                                  is_boundary, boundary_conditions, normals,
-                                 global_to_boundary)
+                                 global_to_boundary[, eval_point])
 
 Populate local Hermite stencil data from global arrays.
 Used within kernels to extract boundary info for specific neighborhoods.
+
+When `eval_point` is given, caches its local index (first stencil point equal by
+value, 0 if absent) in `hermite_data.eval_local_idx` so RHS assembly avoids a
+per-operator search.
 """
 function update_hermite_stencil_data!(
         hermite_data::HermiteStencilData{T},
@@ -128,13 +136,20 @@ function update_hermite_stencil_data!(
         boundary_conditions::Vector{BoundaryCondition{T}},
         normals::AbstractVector{<:AbstractVector{T}},
         global_to_boundary::Vector{Int},
+        eval_point = nothing,
     ) where {T}
     k = length(neighbors)
+    hermite_data.eval_local_idx[] = 0
 
     @inbounds for local_idx in 1:k
         global_idx = neighbors[local_idx]
         hermite_data.data[local_idx] .= global_data[global_idx]
         hermite_data.is_boundary[local_idx] = is_boundary[global_idx]
+
+        if eval_point !== nothing && hermite_data.eval_local_idx[] == 0 &&
+                global_data[global_idx] == eval_point
+            hermite_data.eval_local_idx[] = local_idx
+        end
 
         if is_boundary[global_idx]
             boundary_idx = global_to_boundary[global_idx]
@@ -154,14 +169,14 @@ end
 # ============================================================================
 
 """
-    BoundaryData{T}
+    BoundaryData{T,V}
 
 Wrapper for global boundary information (replaces fragile tuples).
 """
-struct BoundaryData{T}
+struct BoundaryData{T, V <: AbstractVector{T}}
     is_boundary::Vector{Bool}
     boundary_conditions::Vector{BoundaryCondition{T}}
-    normals::Vector{<:AbstractVector{T}}
+    normals::Vector{V}
 end
 
 # ============================================================================


### PR DESCRIPTION
Roadmap PR 3 of 8 (follows #137, #138): eliminates the per-stencil allocations in the weight-build hot loop. Pure refactors — every commit was verified **bitwise-identical** to the pre-change weight matrices (interior and mixed-BC Hermite builds).

## Changes

- **`classify_stencil`** no longer materializes `is_boundary[neighbors]` (a length-k `Vector{Bool}` per stencil, even for pure-interior builds) — replaced with an `@inline` early-exit scan. 96 → 0 bytes/call.
- **`construct_global_to_boundary`** was computed twice per build (`count_nonzeros` + `launch_kernel!`); now computed once in `build_weights_kernel` and threaded through (internal signatures only).
- **`_mono_rhs!`** ran a `findfirst` vector-equality search per operator per stencil to locate the eval point; `HermiteStencilData` now caches the local index (`eval_local_idx::Base.RefValue{Int}`), set once per stencil in `update_hermite_stencil_data!`. Also concretizes `HermiteStencilData.data` and parameterizes `BoundaryData` so `normals` storage is concrete.
- **`∂_normal`** allocated a temporary and constructed `∂(mb, d)` functors on every Neumann/Robin entry; new in-place `∂_normal!` uses a second `HermiteStencilData` workspace with `ntuple(Val(Dim))`-unrolled functor construction. 160 → 0 bytes/call on the Neumann poly-entry path.
- **Monomial inner loops** (`build_monomial_basis`, TODO'd for a while): `@views` rewrote the indexed `*=` into a SubArray-times-scalar that heap-allocated a temporary every iteration (confirmed by `macroexpand`). Replaced with a shared scalar loop `_monomial_products!`. 512–1824 → 0 bytes/call, ~5–6× faster on those paths.
- **Benchmarks**: new `SUITE["Hermite"]["build weights"]` (mixed Dirichlet+Neumann) and `SUITE["Interpolator"]["eval (poly)"]` groups, plus a fix for the pre-existing `let`-block bug that silently discarded the four operator groups' `"build weights"` benchmarks.

## Verification

- Full suite: **1343 passed / 0 failed / 1 broken** (the intentional Enzyme self-skip on Julia ≥ 1.12).
- Bitwise parity of weight matrices asserted after **each** commit (interior + Hermite builds), plus 2340/2340 bitwise-identical monomial outputs across dims 1–4 × degs 0–3.
- PkgBenchmark judge vs `main` (min-time, single-threaded):

| group | time ratio | memory ratio |
|---|---|---|
| `Hermite / build weights` | **0.80** | 0.99 |
| `Interpolator / eval (poly)` | **0.75** | 1.00 |
| `Gradient / build weights` | **0.82** | 1.00 |
| `Partial / build weights` | **0.87** | 1.00 |
| `Directional (per point) / build weights` | **0.78** | 1.00 |
| `MonomialBasis / *` | 0.72–0.95 | 1.00 |

No memory regressions in any group. One time flag — `MonomialBasis/dim=2/deg=0` at 1.14× — was A/B re-measured on both refs: overlapping ~1 ns distributions (target min 0.875 ns vs baseline 0.958 ns), i.e. code-layout jitter on a single-instruction benchmark, not a regression. The `RBF/*` functor micro-rows also read 0.5–0.9× but PR 3 touches none of that code, so those are run-to-run variance, not claimed wins.

<sub>🤖 Beep boop — allocation hunting by Claude; Kyle only pays for the electrons.</sub>
