### PR TITLE
refactor: Float32-generic weight building

### DIFF
--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -107,7 +107,8 @@ export is_self_adjoint, derivative_order
 
 # Some consts and aliases
 const Δ = ∇² # some people like this notation for the Laplacian
-const AVOID_INF = 1.0e-16
+@inline avoid_inf(::Type{T}) where {T <: AbstractFloat} = T(1.0e-16)
+@inline avoid_inf(x::Real) = avoid_inf(typeof(float(x)))
 
 using PrecompileTools
 @setup_workload begin

--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -107,8 +107,11 @@ export is_self_adjoint, derivative_order
 
 # Some consts and aliases
 const Δ = ∇² # some people like this notation for the Laplacian
-@inline avoid_inf(::Type{T}) where {T <: AbstractFloat} = T(1.0e-16)
-@inline avoid_inf(x::Real) = avoid_inf(typeof(float(x)))
+# max guards Float16, where T(1e-16) underflows to zero
+@inline avoid_inf(::Type{T}) where {T <: AbstractFloat} = max(T(1.0e-16), floatmin(T))
+@inline avoid_inf(x::AbstractFloat) = avoid_inf(typeof(x))
+# non-AbstractFloat Reals (e.g. ForwardDiff.Dual) get a promoted constant with zero partials
+@inline avoid_inf(x::Real) = oftype(float(x), 1.0e-16)
 
 using PrecompileTools
 @setup_workload begin

--- a/src/basis/polyharmonic_spline.jl
+++ b/src/basis/polyharmonic_spline.jl
@@ -53,26 +53,26 @@ end
 # ∂ - first partial derivative
 function (op::∂{<:PHS1})(x, xᵢ)
     r = euclidean(x, xᵢ)
-    return (x[op.dim] - xᵢ[op.dim]) / (r + AVOID_INF)
+    return (x[op.dim] - xᵢ[op.dim]) / (r + avoid_inf(r))
 end
 
 function (op::∂{<:PHS1})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -normal[op.dim] / (r + AVOID_INF) +
-        dot_normal * (x[op.dim] - xᵢ[op.dim]) / (r^3 + AVOID_INF)
+    return -normal[op.dim] / (r + avoid_inf(r)) +
+        dot_normal * (x[op.dim] - xᵢ[op.dim]) / (r^3 + avoid_inf(r))
 end
 
 # ∇ - gradient
 function (op::∇{<:PHS1})(x, xᵢ)
     r = euclidean(x, xᵢ)
-    return (x .- xᵢ) / (r + AVOID_INF)
+    return (x .- xᵢ) / (r + avoid_inf(r))
 end
 
 function (op::∇{<:PHS1})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -normal / (r + AVOID_INF) + dot_normal * (x .- xᵢ) / (r^3 + AVOID_INF)
+    return -normal / (r + avoid_inf(r)) + dot_normal * (x .- xᵢ) / (r^3 + avoid_inf(r))
 end
 
 # H - Hessian matrix
@@ -85,7 +85,7 @@ function (op::H{<:PHS1})(x, xᵢ)
     return StaticArraysCore.SMatrix{N, N, T}(
         ntuple(N * N) do k
             i, j = divrem(k - 1, N) .+ 1
-            T(i == j) / (r + AVOID_INF) - Δ[i] * Δ[j] / (r^3 + AVOID_INF)
+            T(i == j) / (r + avoid_inf(r)) - Δ[i] * Δ[j] / (r^3 + avoid_inf(r))
         end,
     )
 end
@@ -94,7 +94,7 @@ end
 function (op::∂²{<:PHS1})(x, xᵢ)
     r = euclidean(x, xᵢ)
     r² = sqeuclidean(x, xᵢ)
-    return (-(x[op.dim] - xᵢ[op.dim])^2 + r²) / (r^3 + AVOID_INF)
+    return (-(x[op.dim] - xᵢ[op.dim])^2 + r²) / (r^3 + avoid_inf(r))
 end
 
 function (op::∂²{<:PHS1})(x, xᵢ, normal)
@@ -102,20 +102,20 @@ function (op::∂²{<:PHS1})(x, xᵢ, normal)
     n_d = normal[op.dim]
     Δ_d = x[op.dim] - xᵢ[op.dim]
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return (2 * n_d * Δ_d + dot_normal) / (r^3 + AVOID_INF) -
-        3 * Δ_d^2 * dot_normal / (r^5 + AVOID_INF)
+    return (2 * n_d * Δ_d + dot_normal) / (r^3 + avoid_inf(r)) -
+        3 * Δ_d^2 * dot_normal / (r^5 + avoid_inf(r))
 end
 
 # ∇² - Laplacian
 function (op::∇²{<:PHS1})(x, xᵢ)
     r = euclidean(x, xᵢ)
-    return 2 / (r + AVOID_INF)
+    return 2 / (r + avoid_inf(r))
 end
 
 function (op::∇²{<:PHS1})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return 2 * dot_normal / (r^3 + AVOID_INF)
+    return 2 * dot_normal / (r^3 + avoid_inf(r))
 end #==============================================================================# #==============================================================================#
 
 #                                    PHS3                                      #
@@ -146,7 +146,7 @@ function (op::∂{<:PHS3})(x, xᵢ, normal)
     n_d = normal[op.dim]
     Δ_d = x[op.dim] - xᵢ[op.dim]
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -3 * (n_d * r + dot_normal * Δ_d / (r + AVOID_INF))
+    return -3 * (n_d * r + dot_normal * Δ_d / (r + avoid_inf(r)))
 end
 
 # ∇ - gradient
@@ -158,7 +158,7 @@ end
 function (op::∇{<:PHS3})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -3 * (normal * r + dot_normal * (x .- xᵢ) / (r + AVOID_INF))
+    return -3 * (normal * r + dot_normal * (x .- xᵢ) / (r + avoid_inf(r)))
 end
 
 # H - Hessian matrix
@@ -171,7 +171,7 @@ function (op::H{<:PHS3})(x, xᵢ)
     return StaticArraysCore.SMatrix{N, N, T}(
         ntuple(N * N) do k
             i, j = divrem(k - 1, N) .+ 1
-            3 * (T(i == j) * r + Δ[i] * Δ[j] / (r + AVOID_INF))
+            3 * (T(i == j) * r + Δ[i] * Δ[j] / (r + avoid_inf(r)))
         end,
     )
 end
@@ -179,7 +179,7 @@ end
 # ∂² - second partial derivative
 function (op::∂²{<:PHS3})(x, xᵢ)
     r = euclidean(x, xᵢ)
-    return 3 * (r + (x[op.dim] - xᵢ[op.dim])^2 / (r + AVOID_INF))
+    return 3 * (r + (x[op.dim] - xᵢ[op.dim])^2 / (r + avoid_inf(r)))
 end
 
 function (op::∂²{<:PHS3})(x, xᵢ, normal)
@@ -188,8 +188,8 @@ function (op::∂²{<:PHS3})(x, xᵢ, normal)
     n_d = normal[op.dim]
     Δ_d = x[op.dim] - xᵢ[op.dim]
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -3 * (2 * Δ_d * n_d + dot_normal - dot_normal * Δ_d^2 / (r² + AVOID_INF)) /
-        (r + AVOID_INF)
+    return -3 * (2 * Δ_d * n_d + dot_normal - dot_normal * Δ_d^2 / (r² + avoid_inf(r))) /
+        (r + avoid_inf(r))
 end
 
 # ∇² - Laplacian
@@ -201,7 +201,7 @@ end
 function (op::∇²{<:PHS3})(x, xᵢ, normal)
     r = euclidean(x, xᵢ)
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -12 * dot_normal / (r + AVOID_INF)
+    return -12 * dot_normal / (r + avoid_inf(r))
 end #==============================================================================# #==============================================================================#
 
 #                                    PHS5                                      #
@@ -274,7 +274,7 @@ function (op::∂²{<:PHS5})(x, xᵢ, normal)
     n_d = normal[op.dim]
     Δ_d = x[op.dim] - xᵢ[op.dim]
     dot_normal = LinearAlgebra.dot(normal, x .- xᵢ)
-    return -5 * (6 * n_d * Δ_d * r + 3 * dot_normal * (r + Δ_d^2 / (r + AVOID_INF)))
+    return -5 * (6 * n_d * Δ_d * r + 3 * dot_normal * (r + Δ_d^2 / (r + avoid_inf(r))))
 end
 
 # ∇² - Laplacian

--- a/src/operators/virtual.jl
+++ b/src/operators/virtual.jl
@@ -17,7 +17,7 @@ function ∂virtual(
         k::T = autoselect_k(data, basis),
     ) where {T <: Int, B <: AbstractRadialBasis}
     N = length(first(data))
-    dx = zeros(N)
+    dx = zeros(eltype(first(data)), N)
     dx[dim] = Δ
 
     self = regrid(data, eval_points, basis; k = k)

--- a/src/solve/execution.jl
+++ b/src/solve/execution.jl
@@ -298,6 +298,6 @@ end
     I[start_pos] = eval_idx
     J[start_pos] = eval_idx
     return @inbounds for op in 1:num_ops
-        V[start_pos, op] = 1.0
+        V[start_pos, op] = one(eltype(V))
     end
 end

--- a/src/solve/operator_second_derivatives.jl
+++ b/src/solve/operator_second_derivatives.jl
@@ -38,7 +38,7 @@ Mathematical derivation:
 function grad_partial_phs3_wrt_x(dim::Int)
     function grad_Lφ_x(x, xi)
         r = euclidean(x, xi)
-        r_safe = r + AVOID_INF
+        r_safe = r + avoid_inf(r)
         δ = x .- xi
         δ_d = δ[dim]
 
@@ -71,7 +71,7 @@ Mathematical derivation:
 function grad_laplacian_phs3_wrt_x()
     function grad_Lφ_x(x, xi)
         r = euclidean(x, xi)
-        r_safe = r + AVOID_INF
+        r_safe = r + avoid_inf(r)
         δ = x .- xi
         return 12 .* δ ./ r_safe
     end

--- a/src/solve/operator_second_derivatives.jl
+++ b/src/solve/operator_second_derivatives.jl
@@ -101,7 +101,7 @@ function grad_partial_phs1_wrt_x(dim::Int)
     function grad_Lφ_x(x, xi)
         r = euclidean(x, xi)
         # At r=0, PHS1 and its derivatives are 0, so gradient contribution is 0
-        if r < 1.0e-12
+        if r < oftype(r, 1.0e-12)
             return zero(x)
         end
         δ = x .- xi
@@ -136,7 +136,7 @@ function grad_laplacian_phs1_wrt_x()
     function grad_Lφ_x(x, xi)
         r = euclidean(x, xi)
         # At r=0, PHS1 Laplacian is singular, return 0 for gradient
-        if r < 1.0e-12
+        if r < oftype(r, 1.0e-12)
             return zero(x)
         end
         r3 = r^3

--- a/test/float32.jl
+++ b/test/float32.jl
@@ -1,0 +1,32 @@
+using RadialBasisFunctions
+using StaticArraysCore
+using HaltonSequences
+
+N = 200
+x32 = [SVector{2, Float32}(p) for p in HaltonPoint(2)[1:N]]
+x64 = [SVector{2, Float64}(p) for p in x32]
+
+basis = PHS(3; poly_deg = 2)
+
+@testset "Float32 end-to-end Laplacian" begin
+    op32 = laplacian(x32; basis = basis)
+    op64 = laplacian(x64; basis = basis)
+    update_weights!(op32)
+    update_weights!(op64)
+
+    @testset "weights are Float32" begin
+        @test eltype(op32.weights) == Float32
+    end
+
+    @testset "weights match Float64 build" begin
+        W32 = Float64.(Matrix(op32.weights))
+        W64 = Matrix(op64.weights)
+        @test isapprox(W32, W64; rtol = sqrt(eps(Float32)))
+    end
+
+    @testset "operator application preserves Float32" begin
+        y32 = sin.(4 .* getindex.(x32, 1)) .+ cos.(3 .* getindex.(x32, 2))
+        out = op32(y32)
+        @test out isa Vector{Float32}
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,10 @@ end
     include("solve/integration/partial_y_end_to_end.jl")
 end
 
+@safetestset "Float32 Support" begin
+    include("float32.jl")
+end
+
 if Base.find_package("LuxCore") !== nothing
     @safetestset "Lux RBFLayer" begin
         include("extensions/lux_ext.jl")


### PR DESCRIPTION
Roadmap PR 4 of 8 (stacked on #139): makes weight building Float32-generic. Float64 results are **bitwise-identical** by construction — verified against the PR 3 parity baseline after every commit. This is the type-layer prerequisite for the GPU solve path (#88).

## Changes

- **`avoid_inf`** replaces `const AVOID_INF = 1.0e-16`: `avoid_inf(::Type{T<:AbstractFloat}) = max(T(1.0e-16), floatmin(T))` + value routes. All 23 use sites migrated (21 in `polyharmonic_spline.jl`, 2 in `operator_second_derivatives.jl`); `grep AVOID_INF` is now empty. The `max(…, floatmin(T))` guard keeps Float16 from underflowing the epsilon to exactly 0.0 (which would produce `Inf` weights), while leaving Float32/Float64 values bit-identical. A generic `Real` fallback (`oftype(float(x), 1.0e-16)`) preserves the old promotion semantics for ForwardDiff Duals — adversarial review caught that the naive `T<:AbstractFloat`-only design broke `FD.gradient` through the PHS derivative functors.
- **Zero-distance tolerances** in `operator_second_derivatives.jl` are now `oftype(r, 1.0e-12)`.
- **Last live Float64 hardcodes** removed: `dx = zeros(eltype(first(data)), N)` in `virtual.jl`; `V[start_pos, op] = one(eltype(V))` in `execution.jl`. (The `Dirichlet/Neumann/Internal` Float64 *defaults* in `types.jl` are intentional and untouched.)
- **New `test/float32.jl`** (`Float32 Support` safetestset): e2e Float32 laplacian — weight eltype is `Float32`, values agree with the Float64 build to `sqrt(eps(Float32))` (measured margin ~36×), and applying the operator to a Float32 field returns `Vector{Float32}`.

## Verification

- Bitwise Float64 weight parity (interior + mixed-BC Hermite) after **every** commit, including the review-fix commit.
- Inference guard: PHS ∂/∂²/∇/∇²/H functors remain 0-alloc with timings within measurement noise (the `avoid_inf` call constant-folds); Float32 inputs now return Float32 (previously silently promoted through Float64 intermediates).
- Adversarial review (2 lenses + per-finding verification): 3 confirmed findings (Dual-breakage ×2, Float16 underflow), all fixed in `3a6a0e4` with repro-verified fixes.
- Full suite: **1346 passed / 0 failed / 1 broken** (baseline 1343 + the 3 new Float32 tests; the broken is the intentional Enzyme self-skip on Julia ≥ 1.12).

<sub>🤖 Beep boop — Claude did the type surgery; the Duals sent a thank-you card.</sub>
