### PR TITLE
feat(operators): structure-preserving operator algebra

### DIFF
--- a/docs/src/guides/operators.md
+++ b/docs/src/guides/operators.md
@@ -39,11 +39,12 @@ AbstractOperator{N}
 │   ├── Divergence       ∇⋅u (vector field → scalar)
 │   ├── Curl             ∇×u (vector field → scalar/vector)
 │   ├── Identity         f (function itself)
-│   ├── ScaledOperator   α * op
+│   ├── ScaledOperator   α * op (algebra result, any rank N)
+│   ├── SumOperator      op₁ + op₂ (algebra result, any rank N)
 │   ├── StrainRate       ½(∇u + (∇u)ᵀ)
 │   ├── RotationRate     ½(∇u − (∇u)ᵀ)
 │   ├── Regrid           interpolation to new points
-│   └── Custom{0}        user-defined / algebra result
+│   └── Custom{0}        user-defined
 ├── N=1 (rank-adding)
 │   ├── Jacobian          [∂fᵢ/∂xⱼ]
 │   └── Custom{1}         user-defined

--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -89,7 +89,7 @@ include("operators/monomial/monomial.jl")
 
 include("operators/operator_algebra.jl")
 include("operators/operator_macro.jl")
-export Identity, ScaledOperator, @operator
+export Identity, ScaledOperator, SumOperator, @operator
 
 # Shared AD utilities (depends on Partial/Laplacian types defined above)
 include("solve/ad_shared.jl")

--- a/src/operators/operator_algebra.jl
+++ b/src/operators/operator_algebra.jl
@@ -13,6 +13,65 @@ struct Identity <: AbstractOperator{0} end
 print_op(::Identity) = "Identity (f)"
 
 # ============================================================================
+# Action Kernels
+# ============================================================================
+
+"""
+    SumKernel{Fs<:Tuple}
+
+Callable summing component basis actions. Supports the standard `(x, xᵢ)` form and
+the Hermite normal form `(x, xᵢ, normal)`.
+"""
+struct SumKernel{Fs <: Tuple}
+    fs::Fs
+end
+(k::SumKernel)(x, xᵢ) = sum(f -> f(x, xᵢ), k.fs)
+(k::SumKernel)(x, xᵢ, normal) = sum(f -> f(x, xᵢ, normal), k.fs)
+
+"""
+    ScaledKernel{T<:Number, F}
+
+Callable scaling a basis action by `α`. Supports the standard `(x, xᵢ)` form and
+the Hermite normal form `(x, xᵢ, normal)`.
+"""
+struct ScaledKernel{T <: Number, F}
+    α::T
+    f::F
+end
+(k::ScaledKernel)(x, xᵢ) = k.α * k.f(x, xᵢ)
+(k::ScaledKernel)(x, xᵢ, normal) = k.α * k.f(x, xᵢ, normal)
+
+# Normal-form support is determined by the wrapped actions, not the kernel methods
+function _supports_normal_form(k::SumKernel, x, n)
+    return all(f -> _supports_normal_form(f, x, n), k.fs)
+end
+_supports_normal_form(k::ScaledKernel, x, n) = _supports_normal_form(k.f, x, n)
+
+# Monomial equivalents: in-place `(b, x)` form, wrapped in ℒMonomialBasis
+struct MonomialSumKernel{Fs <: Tuple} <: Function
+    fs::Fs
+end
+function (k::MonomialSumKernel)(b, x)
+    cache = similar(b)
+    first(k.fs)(b, x)
+    for f in Base.tail(k.fs)
+        f(cache, x)
+        b .+= cache
+    end
+    return nothing
+end
+
+struct MonomialScaledKernel{T <: Number, F} <: Function
+    α::T
+    f::F
+end
+function (k::MonomialScaledKernel)(b, x)
+    k.f(b, x)
+    b .*= k.α
+    return nothing
+end
+
+# ============================================================================
 # Scaled Operator
 # ============================================================================
 
@@ -28,19 +87,20 @@ end
 ScaledOperator{N}(α::T, op::O) where {N, T <: Number, O <: AbstractOperator{N}} =
     ScaledOperator{N, T, O}(α, op)
 
-function (s::ScaledOperator)(basis::AbstractBasis)
-    f = s.op(basis)
-    return (x, xc) -> s.α * f(x, xc)
-end
+(s::ScaledOperator)(basis::AbstractBasis) = _scale_action(s.α, s.op(basis))
+
+_scale_action(α, f) = ScaledKernel(α, f)
+_scale_action(α, fs::Tuple) = map(f -> ScaledKernel(α, f), fs)
 
 function (s::ScaledOperator)(basis::MonomialBasis{Dim, Deg}) where {Dim, Deg}
-    f = s.op(basis)
-    function scaled_basis!(b, x)
-        f(b, x)
-        b .*= s.α
-        return nothing
-    end
-    return ℒMonomialBasis(Dim, Deg, scaled_basis!)
+    return _scale_mono_action(Dim, Deg, s.α, s.op(basis))
+end
+
+function _scale_mono_action(dim, deg, α, f)
+    return ℒMonomialBasis(dim, deg, MonomialScaledKernel(α, f))
+end
+function _scale_mono_action(dim, deg, α, fs::Tuple)
+    return map(f -> ℒMonomialBasis(dim, deg, MonomialScaledKernel(α, f)), fs)
 end
 
 print_op(s::ScaledOperator) = "$(s.α) × $(print_op(s.op))"
@@ -49,6 +109,103 @@ Base.:*(α::Number, op::AbstractOperator{N}) where {N} = ScaledOperator{N}(α, o
 Base.:*(op::AbstractOperator{N}, α::Number) where {N} = ScaledOperator{N}(α, op)
 Base.:-(op::AbstractOperator{N}) where {N} = ScaledOperator{N}(-1, op)
 Base.:/(op::AbstractOperator{N}, α::Number) where {N} = ScaledOperator{N}(inv(α), op)
+
+# ============================================================================
+# Sum Operator
+# ============================================================================
+
+"""
+    SumOperator{N, Ops<:Tuple{Vararg{AbstractOperator}}} <: AbstractOperator{N}
+
+Sum of operators sharing output rank `N`. Created via `op1 + op2` or `op1 - op2`
+(subtraction stores `-1 * op2`); nested sums flatten into a single n-ary term tuple.
+"""
+struct SumOperator{N, Ops <: Tuple{Vararg{AbstractOperator}}} <: AbstractOperator{N}
+    ops::Ops
+end
+SumOperator{N}(ops::Ops) where {N, Ops <: Tuple{Vararg{AbstractOperator}}} =
+    SumOperator{N, Ops}(ops)
+
+_terms(op::AbstractOperator) = (op,)
+_terms(s::SumOperator) = s.ops
+
+function Base.:+(op1::AbstractOperator{N}, op2::AbstractOperator{N}) where {N}
+    return SumOperator{N}((_terms(op1)..., _terms(op2)...))
+end
+Base.:-(op1::AbstractOperator{N}, op2::AbstractOperator{N}) where {N} = op1 + (-op2)
+
+(s::SumOperator)(basis::AbstractBasis) = _combine_actions(map(op -> op(basis), s.ops)...)
+
+function (s::SumOperator)(basis::MonomialBasis{Dim, Deg}) where {Dim, Deg}
+    return _combine_mono_actions(Dim, Deg, map(op -> op(basis), s.ops)...)
+end
+
+function _combine_actions(actions...)
+    _check_no_mixed_actions(actions)
+    return SumKernel(actions)
+end
+function _combine_actions(actions::Tuple...)
+    n = _check_same_arity(actions)
+    return ntuple(i -> SumKernel(map(a -> a[i], actions)), n)
+end
+
+function _combine_mono_actions(dim, deg, actions...)
+    _check_no_mixed_actions(actions)
+    return ℒMonomialBasis(dim, deg, MonomialSumKernel(actions))
+end
+function _combine_mono_actions(dim, deg, actions::Tuple...)
+    n = _check_same_arity(actions)
+    return ntuple(
+        i -> ℒMonomialBasis(dim, deg, MonomialSumKernel(map(a -> a[i], actions))), n
+    )
+end
+
+function _check_no_mixed_actions(actions)
+    return if any(a -> a isa Tuple, actions)
+        throw(
+            ArgumentError(
+                "Cannot sum operators whose basis actions mix single callables and " *
+                    "per-dimension tuples (e.g. a scalar operator such as Laplacian with " *
+                    "a gradient-family operator such as Divergence or Jacobian)."
+            )
+        )
+    end
+end
+
+function _check_same_arity(actions)
+    n = length(first(actions))
+    all(a -> length(a) == n, actions) || throw(
+        ArgumentError("Cannot sum gradient-family operators with different dimensions.")
+    )
+    return n
+end
+
+print_op(s::SumOperator) = join(map(print_op, s.ops), " + ")
+
+# ============================================================================
+# Evaluation of Composed Operators
+# ============================================================================
+
+# Rank-0 gradient-family compositions (e.g. Divergence + Divergence) carry tuple
+# weights whose contraction semantics are defined by the leading concrete operator;
+# rewrap so _eval_op dispatches on that type.
+_leading_op(op::AbstractOperator) = op
+_leading_op(s::ScaledOperator) = _leading_op(s.op)
+_leading_op(s::SumOperator) = _leading_op(first(s.ops))
+
+function _rewrap_leading(op::RadialBasisOperator)
+    return RadialBasisOperator(
+        _leading_op(op.ℒ), op.weights, op.data, op.eval_points, op.adjl, op.basis,
+        is_cache_valid(op); device = op.device,
+    )
+end
+
+function _eval_op(op::RadialBasisOperator{<:SumOperator{0}}, x::AbstractMatrix)
+    return _eval_op(_rewrap_leading(op), x)
+end
+function _eval_op(op::RadialBasisOperator{<:ScaledOperator{0}}, x::AbstractMatrix)
+    return _eval_op(_rewrap_leading(op), x)
+end
 
 # ============================================================================
 # Operator Algebra on RadialBasisOperator (precomputed weights)
@@ -65,24 +222,6 @@ for op in (:+, :-)
             ℒ, new_weights, op1.data, op1.eval_points, op1.adjl, op1.basis, true;
             device = op1.device,
         )
-    end
-end
-
-for op in (:+, :-)
-    @eval function Base.$op(op1::AbstractOperator{N}, op2::AbstractOperator{N}) where {N}
-        function additive_ℒ(basis)
-            return additive_ℒrbf(x1, x2) = Base.$op(op1(basis)(x1, x2), op2(basis)(x1, x2))
-        end
-        function additive_ℒ(basis::MonomialBasis{Dim, Deg}) where {Dim, Deg}
-            f1 = op1(basis)
-            f2 = op2(basis)
-            function additive_ℒMon(b, x)
-                b .= Base.$op(f1(x), f2(x))
-                return nothing
-            end
-            return ℒMonomialBasis(Dim, Deg, additive_ℒMon)
-        end
-        return Custom{N}(additive_ℒ)
     end
 end
 

--- a/src/operators/operator_algebra.jl
+++ b/src/operators/operator_algebra.jl
@@ -140,7 +140,7 @@ end
 # only meaningful when every such term contracts identically.
 function _check_same_contraction(ops)
     leads = filter(
-        op -> op isa AbstractGradientOperator{<:Any, 0}, map(_leading_op, ops)
+        op -> op isa AbstractJacobianOperator{<:Any, 0}, map(_leading_op, ops)
     )
     length(leads) < 2 && return nothing
     lead = first(leads)

--- a/src/operators/operator_algebra.jl
+++ b/src/operators/operator_algebra.jl
@@ -130,7 +130,32 @@ _terms(op::AbstractOperator) = (op,)
 _terms(s::SumOperator) = s.ops
 
 function Base.:+(op1::AbstractOperator{N}, op2::AbstractOperator{N}) where {N}
-    return SumOperator{N}((_terms(op1)..., _terms(op2)...))
+    ops = (_terms(op1)..., _terms(op2)...)
+    _check_same_contraction(ops)
+    return SumOperator{N}(ops)
+end
+
+# Rank-0 gradient-family operators share the identical tuple-of-∂ basis action;
+# their math lives solely in per-type _eval_op contractions, so summed weights are
+# only meaningful when every such term contracts identically.
+function _check_same_contraction(ops)
+    leads = filter(
+        op -> op isa AbstractGradientOperator{<:Any, 0}, map(_leading_op, ops)
+    )
+    length(leads) < 2 && return nothing
+    lead = first(leads)
+    for op in Base.tail(leads)
+        nameof(typeof(op)) === nameof(typeof(lead)) || throw(
+            ArgumentError(
+                "Cannot sum operators with different contraction semantics: " *
+                    "$(print_op(lead)) and $(print_op(op)). These operators share " *
+                    "identical gradient weights and differ only in how the weights " *
+                    "are contracted, so their sum is not expressible as a single " *
+                    "weighted operator."
+            )
+        )
+    end
+    return nothing
 end
 Base.:-(op1::AbstractOperator{N}, op2::AbstractOperator{N}) where {N} = op1 + (-op2)
 
@@ -205,6 +230,12 @@ function _eval_op(op::RadialBasisOperator{<:SumOperator{0}}, x::AbstractMatrix)
 end
 function _eval_op(op::RadialBasisOperator{<:ScaledOperator{0}}, x::AbstractMatrix)
     return _eval_op(_rewrap_leading(op), x)
+end
+function _eval_op(op::RadialBasisOperator{<:SumOperator{0}}, y, x)
+    return _eval_op(_rewrap_leading(op), y, x)
+end
+function _eval_op(op::RadialBasisOperator{<:ScaledOperator{0}}, y, x)
+    return _eval_op(_rewrap_leading(op), y, x)
 end
 
 # ============================================================================

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -53,6 +53,8 @@ eigenvalue problems.
 is_self_adjoint(::AbstractOperator) = false
 is_self_adjoint(::Laplacian) = true
 is_self_adjoint(::Identity) = true
+is_self_adjoint(s::ScaledOperator) = is_self_adjoint(s.op)
+is_self_adjoint(s::SumOperator) = all(is_self_adjoint, s.ops)
 
 """
     derivative_order(op) -> Union{Int, Missing}
@@ -70,4 +72,6 @@ derivative_order(::AbstractJacobianOperator) = 1
 derivative_order(::Hessian) = 2
 derivative_order(::Directional) = 1
 derivative_order(s::ScaledOperator) = derivative_order(s.op)
+# maximum propagates missing: max(x, missing) === missing
+derivative_order(s::SumOperator) = maximum(derivative_order, s.ops)
 derivative_order(::Custom) = missing

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -24,6 +24,8 @@ const VectorFieldOperator = Union{Divergence, Curl, StrainRate, RotationRate}
 
 requires_vector_input(::AbstractOperator) = false
 requires_vector_input(::VectorFieldOperator) = true
+requires_vector_input(s::ScaledOperator) = requires_vector_input(s.op)
+requires_vector_input(s::SumOperator) = any(requires_vector_input, s.ops)
 
 """
     is_symmetric(op) -> Bool

--- a/test/operators/operator_algebra.jl
+++ b/test/operators/operator_algebra.jl
@@ -148,3 +148,44 @@ end
     # scalar action + per-dimension tuple action cannot combine at weight build
     @test_throws ArgumentError (Laplacian() + Divergence{2}())(pts)
 end
+
+@testset "Heterogeneous gradient-family sums are rejected" begin
+    @test_throws ArgumentError Divergence{2}() + Curl{2}()
+    @test_throws ArgumentError Curl{2}() + Divergence{2}()
+    @test_throws ArgumentError StrainRate{2}() + RotationRate{2}()
+    @test_throws ArgumentError Divergence{2}() - Curl{2}()
+    @test_throws ArgumentError 2.0 * Divergence{2}() + Curl{2}()
+    # precomputed-weights path routes through the same check
+    @test_throws ArgumentError divergence(pts) + curl(pts)
+    # homogeneous sums remain valid
+    @test (Divergence{2}() + Divergence{2}()) isa SumOperator
+    @test (StrainRate{2}() + StrainRate{2}()) isa SumOperator
+end
+
+@testset "requires_vector_input forwards through composition" begin
+    @test requires_vector_input(Divergence{2}() + Divergence{2}())
+    @test requires_vector_input(2.0 * Divergence{2}())
+    @test !requires_vector_input(Laplacian() + Laplacian())
+    @test !requires_vector_input(2.0 * Laplacian())
+    q = quadratic.(pts)
+    @test_throws ArgumentError (Divergence{2}() + Divergence{2}())(pts)(q)
+    @test_throws ArgumentError (2.0 * Divergence{2}())(pts)(q)
+end
+
+@testset "In-place evaluation of composed rank-0 operators" begin
+    v = hcat(vfx.(pts), vfy.(pts))
+    op = (Divergence{2}() + Divergence{2}())(pts)
+    y = zeros(length(pts))
+    op(y, v)
+    @test isapprox(y, op(v); rtol = 1.0e-10)
+    scaled = (2.0 * Divergence{2}())(pts)
+    ys = zeros(length(pts))
+    scaled(ys, v)
+    @test isapprox(ys, 2.0 .* divergence(pts)(v); rtol = 1.0e-10)
+    # scalar composed sums keep working in-place
+    lap_sum = (Laplacian() + Laplacian())(pts)
+    q = quadratic.(pts)
+    yl = zeros(length(pts))
+    lap_sum(yl, q)
+    @test isapprox(yl, lap_sum(q); rtol = 1.0e-10)
+end

--- a/test/operators/operator_algebra.jl
+++ b/test/operators/operator_algebra.jl
@@ -58,3 +58,93 @@ end
     @test RadialBasisFunctions.print_op(s) == "3.0 × ∂ⁿf/∂xᵢ (n = 1, i = 1)"
     @test RadialBasisFunctions.print_op(Identity()) == "Identity (f)"
 end
+
+# ============================================================================
+# Structure-preserving algebra (SumOperator / typed kernels)
+# ============================================================================
+
+pts = SVector{2}.(HaltonPoint(2)[1:200])
+vfx(p) = 2 * p[1] + 3 * p[2]
+vfy(p) = p[1] - p[2]
+quadratic(p) = p[1]^2 + p[2]^2
+
+@testset "SumOperator structure" begin
+    s = Partial(1, 1) + Partial(1, 2)
+    @test s isa SumOperator
+    @test length(s.ops) == 2
+    # nested sums flatten into n-ary term tuples
+    s3 = s + Laplacian()
+    @test s3 isa SumOperator
+    @test length(s3.ops) == 3
+    # subtraction stores -1 × op
+    sub = Partial(1, 1) - Partial(1, 2)
+    @test sub isa SumOperator
+    @test sub.ops[2] isa RadialBasisFunctions.ScaledOperator
+    @test sub.ops[2].α == -1
+end
+
+@testset "Gradient-family sum: Divergence + Divergence" begin
+    v = hcat(vfx.(pts), vfy.(pts))
+    dsum = Divergence{2}() + Divergence{2}()
+    @test dsum isa SumOperator
+    op = dsum(pts)
+    single = divergence(pts)
+    @test isapprox(op(v), 2 .* single(v); rtol = 1.0e-10)
+    # ∇⋅(2x + 3y, x − y) = 1, doubled = 2
+    @test isapprox(op(v), fill(2.0, length(pts)); rtol = 1.0e-6)
+end
+
+@testset "Scaled gradient-family: 2.0 * Jacobian" begin
+    scaled = 2.0 * Jacobian{2}()
+    @test scaled isa RadialBasisFunctions.ScaledOperator
+    op = scaled(pts)
+    single = jacobian(pts)
+    q = quadratic.(pts)
+    @test isapprox(op(q), 2.0 .* single(q); rtol = 1.0e-10)
+end
+
+@testset "Gradient-family subtraction cancels" begin
+    v = hcat(vfx.(pts), vfy.(pts))
+    dzero = (Divergence{2}() - Divergence{2}())(pts)
+    @test all(abs.(dzero(v)) .< 1.0e-8)
+end
+
+@testset "Scalar sums match weight-combining path" begin
+    lap_sum = (Laplacian() + Laplacian())(pts)
+    combined = laplacian(pts) + laplacian(pts)
+    @test isapprox(Matrix(lap_sum.weights), Matrix(combined.weights); rtol = 1.0e-10)
+    q = quadratic.(pts)
+    # ∇²(x² + y²) = 4, doubled = 8
+    @test isapprox(lap_sum(q), fill(8.0, length(pts)); rtol = 1.0e-6)
+end
+
+@testset "Composed trait propagation" begin
+    @test derivative_order(Partial(1, 1) + Partial(2, 1)) == 2
+    @test derivative_order(2.0 * (Partial(1, 1) + Partial(2, 2))) == 2
+    # Custom's derivative_order is missing; it must propagate through composition
+    @test ismissing(derivative_order(Laplacian() + Custom{0}(b -> (x, xᵢ) -> b(x, xᵢ))))
+    @test ismissing(derivative_order(Partial(1, 1) + 2.0 * Custom{0}(b -> (x, xᵢ) -> b(x, xᵢ))))
+    @test is_self_adjoint(Laplacian() + Identity())
+    @test is_self_adjoint(2.0 * Laplacian())
+    @test !is_self_adjoint(Laplacian() + Partial(1, 1))
+end
+
+@testset "@operator trees are structure-preserving" begin
+    k2 = 1.7
+    helm = @operator ∇² + k2 * f
+    @test helm isa SumOperator
+    @test length(helm.ops) == 2
+    @test helm.ops[2] isa RadialBasisFunctions.ScaledOperator
+    aniso = @operator 2.0 * ∂²(1) + 0.5 * ∂²(2)
+    @test aniso isa SumOperator
+    op = helm(pts)
+    hand = Matrix(laplacian(pts).weights) .+ k2 .* Matrix(Identity()(pts).weights)
+    @test isapprox(Matrix(op.weights), hand; rtol = 1.0e-10)
+end
+
+@testset "Composed rank mismatch and mixed-action errors" begin
+    @test_throws ArgumentError (Laplacian() + Laplacian()) + Jacobian{2}()
+    @test_throws ArgumentError 2.0 * Laplacian() + Jacobian{2}()
+    # scalar action + per-dimension tuple action cannot combine at weight build
+    @test_throws ArgumentError (Laplacian() + Divergence{2}())(pts)
+end


### PR DESCRIPTION
Roadmap PR 6 of 8 (stacked on #141). Makes operator algebra **structure-preserving**: typed callable kernels replace the closures that erased operator structure — and that were outright broken for the gradient family (`Divergence() + Divergence()` and `2.0 * Jacobian()` MethodError'd on weight build before this PR).

## Changes

- **`SumOperator{N, Ops}`** (exported): n-ary, flattening (`(a+b)+c` and `a+(b+c)` produce the same flat term tuple); `a - b = a + (-1 · b)`. Rank-mismatch `ArgumentError`s and the precomputed-weights fast path (`+`/`-` on `RadialBasisOperator` via `_combine_weights`) are unchanged.
- **`SumKernel` / `ScaledKernel`** (internal) typed actions with both `(x, xᵢ)` and Hermite `(x, xᵢ, normal)` arities — the old closures never forwarded the 3-arg form, so composed operators with Neumann/Robin BCs are a **new capability**. `_supports_normal_form` recurses through the kernels so the PR 1 `applicable`-guard stays honest instead of falsely passing on composed kernels.
- **`MonomialSumKernel` / `MonomialScaledKernel`** keep the `ℒMonomialBasis` protocol for polynomial augmentation.
- **Trait composition:** `derivative_order(sum) = maximum(…)` (missing-propagating), `is_self_adjoint` via `all`, `requires_vector_input` forwarded through both wrappers.
- **Safety (from adversarial review):** heterogeneous rank-0 gradient-family sums (e.g. `Divergence + Curl`) used to build *silently wrong* results using only the leading term's contraction — they now throw a clear `ArgumentError` on construction, in both lazy and precomputed paths. In-place `op(y, x)` / `mul!` now work for composed rank-0 operators. Docs type-tree updated (algebra no longer returns `Custom`).

## Verification

- Plain-operator weight builds: bitwise-identical to the stack baseline after every commit.
- Previously-working composed forms: `2.5 * Laplacian()` and the `@operator` Helmholtz tree are **bitwise-identical** across the refactor; `Partial+Partial` composed weights match to 2.6e-14 relative (root-caused via 4-way bisect to SIMD contraction differences in how the old closure compiled inside the assembly kernel — below the base branch's own 2.6e-11 noise floor vs hand-composed weights; the new path matches plain single-operator arithmetic).
- New capability tested against analytic references: `Div+Div` on `(2x+3y, x−y)` ≈ 2 everywhere; `2·Jacobian` ≈ 2× single; composed Hermite (mixed Dirichlet+Neumann) `Lap+Lap == 2·Lap` on all rows to 1e-14.
- Full suite: **1393 passed / 0 failed / 1 broken** (+47 vs baseline, all in the Operator Algebra testset — 61/61 there; the broken is the intentional Enzyme self-skip).

<sub>🤖 Beep boop — Claude taught the operators algebra; the closures have been let go with severance.</sub>
