### PR TITLE
feat(operators): VirtualPartial operator + basis-protocol docs

### DIFF
--- a/docs/src/guides/operators.md
+++ b/docs/src/guides/operators.md
@@ -178,6 +178,17 @@ Available functor types (accessed via `RadialBasisFunctions.∂` etc.):
 
 These functors are the interface between operators and [Custom Operators](@ref "Custom Operators"). See that page for how to use them.
 
+### Two differentiation protocols
+
+The names `∂`, `∂²`, `∇`, `∇²`, `H`, and `∂mixed` deliberately serve **two protocols**, selected by the basis type:
+
+| Basis | What `∂(basis, dim)` returns | How it evaluates |
+|:---|:---|:---|
+| `AbstractRadialBasis` (PHS, IMQ, Gaussian) | A functor **struct** (`∂`, `∇²`, …, defined in `src/basis/basis.jl`) | `(x, xᵢ) -> scalar` |
+| `MonomialBasis` | A **factory function** result: `ℒMonomialBasis` (defined in `src/operators/monomial/monomial.jl`) | in-place `(b, x)` fill of the differentiated monomial vector |
+
+This dual identity is load-bearing: an operator action like `(op::Partial)(basis) = ∂(basis, op.order, op.dim)` is written once, and weight building applies it to the RBF basis for the collocation rows and to the `MonomialBasis` for the polynomial-augmentation rows — each returning the form the assembly kernels expect. When adding a basis or operator, implement both halves; do not try to unify them.
+
 ## Operator Algebra
 
 Built `RadialBasisOperator`s can be combined with `+` and `-`. This operates on precomputed weights and returns a new operator:

--- a/src/RadialBasisFunctions.jl
+++ b/src/RadialBasisFunctions.jl
@@ -83,7 +83,7 @@ include("operators/rotation_rate.jl")
 export RotationRate, rotation_rate
 
 include("operators/virtual.jl")
-export ∂virtual
+export VirtualPartial, ∂virtual
 
 include("operators/monomial/monomial.jl")
 

--- a/src/basis/basis.jl
+++ b/src/basis/basis.jl
@@ -10,6 +10,13 @@ abstract type AbstractRadialBasis <: AbstractBasis end
 
 # Operator functor types - callable structs for RBF differential operators
 # These replace closures with proper multiple dispatch
+#
+# Two basis-differentiation protocols share the names ∂/∇/∂²/∇²/H/∂mixed (load-bearing,
+# do not unify): for AbstractRadialBasis they are the functor STRUCTS below, evaluated
+# as (x, xᵢ) -> scalar; for MonomialBasis they are factory FUNCTIONS returning an
+# ℒMonomialBasis that fills the differentiated monomial vector in place (see
+# operators/monomial/monomial.jl). Operator actions such as (op::Partial)(basis) are
+# written once and serve both.
 
 """
     ∂{B<:AbstractRadialBasis}

--- a/src/operators/monomial/monomial.jl
+++ b/src/operators/monomial/monomial.jl
@@ -1,3 +1,15 @@
+"""
+    ℒMonomialBasis{Dim,Deg,F}
+
+A differentiated `MonomialBasis`: wraps an in-place evaluator `f(b, x)` that fills `b`
+with the operator applied to each monomial term at `x`.
+
+This is the monomial half of the package's two basis-differentiation protocols: for
+`MonomialBasis`, `∂`/`∇`/`∂²`/`∇²`/`H`/`∂mixed` are factory functions returning an
+`ℒMonomialBasis`, whereas for `AbstractRadialBasis` the same names are functor structs
+(see `src/basis/basis.jl`). Operator actions such as `(op::Partial)(basis)` are written
+once and serve both protocols.
+"""
 struct ℒMonomialBasis{Dim, Deg, F <: Function}
     f::F
     function ℒMonomialBasis(dim::T, deg::T, f) where {T <: Int}

--- a/src/operators/operator_traits.jl
+++ b/src/operators/operator_traits.jl
@@ -73,6 +73,7 @@ derivative_order(::Laplacian) = 2
 derivative_order(::AbstractJacobianOperator) = 1
 derivative_order(::Hessian) = 2
 derivative_order(::Directional) = 1
+derivative_order(::VirtualPartial) = 1
 derivative_order(s::ScaledOperator) = derivative_order(s.op)
 # maximum propagates missing: max(x, missing) === missing
 derivative_order(s::SumOperator) = maximum(derivative_order, s.ops)

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -599,7 +599,12 @@ function LinearAlgebra.:⋅(
     return vec(sum(result; dims = 2))  # Sum across derivative dimension → Vector (N,)
 end
 
-# update weights
+"""
+    update_weights!(op::RadialBasisOperator)
+
+Rebuild the stencil weights of `op` from its current `data` and `eval_points`, then mark
+the weight cache as valid.
+"""
 function update_weights!(op::RadialBasisOperator)
     op.weights .= _build_weights(op.ℒ, op)
     validate_cache!(op)

--- a/src/operators/virtual.jl
+++ b/src/operators/virtual.jl
@@ -19,6 +19,9 @@ operator is the partial derivative with respect to `dim`. Virtual operators inte
 data to structured points at a distance `Δ` for which standard finite difference formulas
 can be applied. The result is a standard [`RadialBasisOperator`](@ref), so weight caching
 and [`update_weights!`](@ref) come for free.
+
+Defaults to a forward difference (`backward=false`). Note the convenience form without
+`eval_points` instead defaults to a backward difference (`backward=true`).
 """
 function ∂virtual(
         data::AbstractVector,
@@ -42,6 +45,9 @@ where the operator is the partial derivative with respect to `dim`. Virtual oper
 interpolate the data to structured points at a distance `Δ` for which standard finite
 difference formulas can be applied. The result is a standard [`RadialBasisOperator`](@ref),
 so weight caching and [`update_weights!`](@ref) come for free.
+
+Defaults to a backward difference (`backward=true`), unlike the form with explicit
+`eval_points`, which defaults to forward (`backward=false`).
 """
 function ∂virtual(
         data::AbstractVector,
@@ -54,16 +60,19 @@ function ∂virtual(
     return ∂virtual(data, data, dim, Δ, basis; backward = backward, k = k)
 end
 
-# Custom _build_weights: difference of two Regrid weight builds. The shifted point set
-# finds its own neighbors so stencils follow the shifted evaluation points.
+# Custom _build_weights: difference of two Regrid weight builds. Both point sets find
+# their neighbors from the current data (adjl only supplies the stencil size) so that
+# rebuilds via update_weights! stay consistent after in-place data mutation.
 function _build_weights(ℒ::VirtualPartial, data, eval_points, adjl, basis; device = CPU())
     N = length(first(data))
     dx = zeros(eltype(first(data)), N)
     dx[ℒ.dim] = ℒ.Δ
 
-    self = _build_weights(Regrid(), data, eval_points, adjl, basis; device = device)
+    k = length(first(adjl))
+    self_adjl = find_neighbors(data, eval_points, k)
+    self = _build_weights(Regrid(), data, eval_points, self_adjl, basis; device = device)
     shifted = ℒ.backward ? eval_points .- Ref(dx) : eval_points .+ Ref(dx)
-    shifted_adjl = find_neighbors(data, shifted, length(first(adjl)))
+    shifted_adjl = find_neighbors(data, shifted, k)
     other = _build_weights(Regrid(), data, shifted, shifted_adjl, basis; device = device)
 
     return if ℒ.backward

--- a/src/operators/virtual.jl
+++ b/src/operators/virtual.jl
@@ -1,11 +1,24 @@
-# convienience constructors
 """
-    function ∂virtual(data, eval_points, dim, Δ, basis; k=autoselect_k(data, basis))
+    VirtualPartial{T<:Real} <: AbstractOperator{0}
 
-Builds a virtual `RadialBasisOperator` whichi will be evaluated at `eval_points` where the
+Operator for the first partial derivative with respect to `dim`, computed virtually:
+the data is interpolated (regridded) to points shifted by `Δ` along `dim` and a
+one-sided finite difference is taken between the shifted and unshifted interpolants.
+"""
+struct VirtualPartial{T <: Real} <: AbstractOperator{0}
+    dim::Int
+    Δ::T
+    backward::Bool
+end
+
+"""
+    function ∂virtual(data, eval_points, dim, Δ, basis; backward=false, k=autoselect_k(data, basis))
+
+Builds a virtual `RadialBasisOperator` which will be evaluated at `eval_points` where the
 operator is the partial derivative with respect to `dim`. Virtual operators interpolate the
 data to structured points at a distance `Δ` for which standard finite difference formulas
-can be applied.
+can be applied. The result is a standard [`RadialBasisOperator`](@ref), so weight caching
+and [`update_weights!`](@ref) come for free.
 """
 function ∂virtual(
         data::AbstractVector,
@@ -16,33 +29,19 @@ function ∂virtual(
         backward = false,
         k::T = autoselect_k(data, basis),
     ) where {T <: Int, B <: AbstractRadialBasis}
-    N = length(first(data))
-    dx = zeros(eltype(first(data)), N)
-    dx[dim] = Δ
-
-    self = regrid(data, eval_points, basis; k = k)
-    update_weights!(self)
-
-    return if backward
-        li = regrid(data, eval_points .- Ref(dx), basis; k = k)
-        update_weights!(li)
-        w = (self.weights .- li.weights) ./ Δ
-        x -> w * x
-    else # forward difference
-        ri = regrid(data, eval_points .+ Ref(dx), basis; k = k)
-        update_weights!(ri)
-        w = (ri.weights .- self.weights) ./ Δ
-        x -> w * x
-    end
+    return RadialBasisOperator(
+        VirtualPartial(dim, Δ, backward), data; eval_points = eval_points, basis = basis, k = k
+    )
 end
 
 """
-    function ∂virtual(data, dim, Δ, basis; k=autoselect_k(data, basis))
+    function ∂virtual(data, dim, Δ, basis; backward=true, k=autoselect_k(data, basis))
 
-Builds a virtual `RadialBasisOperator` whichi will be evaluated at the input points (`data`)
+Builds a virtual `RadialBasisOperator` which will be evaluated at the input points (`data`)
 where the operator is the partial derivative with respect to `dim`. Virtual operators
 interpolate the data to structured points at a distance `Δ` for which standard finite
-difference formulas can be applied.
+difference formulas can be applied. The result is a standard [`RadialBasisOperator`](@ref),
+so weight caching and [`update_weights!`](@ref) come for free.
 """
 function ∂virtual(
         data::AbstractVector,
@@ -53,4 +52,47 @@ function ∂virtual(
         k::T = autoselect_k(data, basis),
     ) where {T <: Int, B <: AbstractRadialBasis}
     return ∂virtual(data, data, dim, Δ, basis; backward = backward, k = k)
+end
+
+# Custom _build_weights: difference of two Regrid weight builds. The shifted point set
+# finds its own neighbors so stencils follow the shifted evaluation points.
+function _build_weights(ℒ::VirtualPartial, data, eval_points, adjl, basis; device = CPU())
+    N = length(first(data))
+    dx = zeros(eltype(first(data)), N)
+    dx[ℒ.dim] = ℒ.Δ
+
+    self = _build_weights(Regrid(), data, eval_points, adjl, basis; device = device)
+    shifted = ℒ.backward ? eval_points .- Ref(dx) : eval_points .+ Ref(dx)
+    shifted_adjl = find_neighbors(data, shifted, length(first(adjl)))
+    other = _build_weights(Regrid(), data, shifted, shifted_adjl, basis; device = device)
+
+    return if ℒ.backward
+        (self .- other) ./ ℒ.Δ
+    else # forward difference
+        (other .- self) ./ ℒ.Δ
+    end
+end
+
+function _build_weights(
+        ::VirtualPartial,
+        data::AbstractVector,
+        eval_points::AbstractVector,
+        adjl::AbstractVector,
+        basis::AbstractRadialBasis,
+        is_boundary::Vector{Bool},
+        boundary_conditions::Vector{<:BoundaryCondition},
+        normals::Vector{<:AbstractVector};
+        device = CPU(),
+    )
+    throw(
+        ArgumentError(
+            "VirtualPartial does not support Hermite boundary conditions. Use partial " *
+                "with hermite=... instead.",
+        ),
+    )
+end
+
+# pretty printing
+function print_op(op::VirtualPartial)
+    return "virtual ∂f/∂x$(op.dim) ($(op.backward ? "backward" : "forward") difference, Δ = $(op.Δ))"
 end

--- a/test/operators/virtual.jl
+++ b/test/operators/virtual.jl
@@ -2,6 +2,7 @@ using RadialBasisFunctions
 using StaticArraysCore
 using Statistics
 using HaltonSequences
+using SparseArrays
 using Random: MersenneTwister
 
 rng = MersenneTwister(678)
@@ -48,4 +49,31 @@ end
     ∂y = ∂virtual(x, x2, 2, Δ, PHS(3; poly_deg = 2))
     @test mean_percent_error(∂x(y), df_dx.(x2)) < 10
     @test mean_percent_error(∂y(y), df_dy.(x2)) < 10
+end
+
+@testset "VirtualPartial Operator" begin
+    op = ∂virtual(x, 1, Δ, PHS(3; poly_deg = 2))
+    @test op isa RadialBasisOperator
+    @test op.ℒ isa VirtualPartial
+    @test derivative_order(op.ℒ) == 1
+
+    @testset "weights cached across evaluations" begin
+        @test is_cache_valid(op)
+        first_result = op(y)
+        @test is_cache_valid(op)
+        @test op(y) == first_result
+
+        RadialBasisFunctions.invalidate_cache!(op)
+        @test !is_cache_valid(op)
+        @test op(y) == first_result
+        @test is_cache_valid(op)
+    end
+
+    @testset "backward matches forward within O(Δ)" begin
+        ∂x_forward = ∂virtual(x, x, 1, Δ, PHS(3; poly_deg = 2); backward = false)
+        ∂x_backward = ∂virtual(x, x, 1, Δ, PHS(3; poly_deg = 2); backward = true)
+        @test all(isfinite, nonzeros(∂x_backward.weights))
+        @test mean_percent_error(∂x_backward(y), df_dx.(x)) < 10
+        @test isapprox(∂x_forward(y), ∂x_backward(y); rtol = 100 * Δ)
+    end
 end

--- a/test/operators/virtual.jl
+++ b/test/operators/virtual.jl
@@ -77,3 +77,15 @@ end
         @test isapprox(∂x_forward(y), ∂x_backward(y); rtol = 100 * Δ)
     end
 end
+
+@testset "update_weights! after in-place data mutation" begin
+    xm = map(_ -> SVector{2}(rand(rng, 2)), 1:500)
+    xe = map(_ -> SVector{2}(0.1 .+ 0.8 .* rand(rng, 2)), 1:100)
+    op = ∂virtual(xm, xe, 1, Δ, PHS(3; poly_deg = 2))
+    for i in eachindex(xm)
+        xm[i] = xm[i] + SVector{2}(0.05 .* (rand(rng, 2) .- 0.5))
+    end
+    update_weights!(op)
+    fresh = ∂virtual(xm, xe, 1, Δ, PHS(3; poly_deg = 2))
+    @test op.weights == fresh.weights
+end


### PR DESCRIPTION
Roadmap PR 7 of 8 (stacked on #142). `∂virtual` finally returns what its docstring always claimed: a real `RadialBasisOperator` — gaining weight caching, `update_weights!`, `show`, and traits — via a new `VirtualPartial` operator whose `_build_weights` override composes two `Regrid` builds (the exact precedent set by `Directional`).

## Changes

- **`VirtualPartial{T} <: AbstractOperator{0}`** (`dim`, `Δ`, `backward`; exported alongside `∂virtual`): the override differences two `Regrid` interpolations at `eval_points ± Δ·e_dim`, forward `(W₊ − W₀)/Δ` or backward `(W₀ − W₋)/Δ` — **bit-for-bit identical** to the old closure's weights across all 8 parity cases ({2D, 3D} × {forward, backward} × {explicit eval points, convenience form}). Hermite boundary data throws a clear `ArgumentError` (finite-difference virtual operators don't support it). `derivative_order = 1`; fixed the "whichi" docstring typos.
- **Review fixes** (`df79c2f`): (a) the self-stencil neighbor list is regenerated from current data at build time, so `update_weights!` after in-place point mutation now matches a freshly constructed operator exactly — previously the stale stored adjl mixed with fresh shifted-stencil neighbors and the `1/Δ` division amplified the mismatch ~94×, silently; (b) exported `update_weights!` now has a docstring, so the new `[@ref]` links resolve and the Documenter build passes (repro'd fail → clean build); (c) the intentionally-opposite `backward` defaults of the two arities are now documented explicitly.
- **Two-protocols documentation**: `∂/∇/∂²/∇²/H/∂mixed` are functor structs for `AbstractRadialBasis` but factory functions returning `ℒMonomialBasis` for `MonomialBasis` — load-bearing (operator actions written once serve both), now documented at both definition sites and in `docs/src/guides/operators.md`.

## Verification

- Old-vs-new weight parity: max abs diff 0.0 (bitwise, incl. sparse structure) on all 8 seeded cases; the PR 3 interior+Hermite parity gate stays bitwise green.
- The pre-existing `test/operators/virtual.jl` assertions pass verbatim (compatibility contract); new testset covers operator identity, cache/invalidate semantics, backward variant, forward≈backward at O(Δ), and a stale-adjl regression test.
- Minimal Documenter build: exit 0, zero unresolved `@ref`s.
- Full suite: **1406 passed / 0 failed / 1 broken** (+13 vs baseline, all in the Virtual testset — 21/21 there; the broken is the intentional Enzyme self-skip).

<sub>🤖 Beep boop — Claude made the docstring stop lying; the operator was the easy part.</sub>
