### PR TITLE
refactor(operators)!: remove positional eval_points constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ Breaking release. The operator constructor surface was simplified and several ex
 #### Positional `eval_points` and positional Hermite constructor tiers removed
 
 Removed from `partial`, `laplacian`, `gradient`, `jacobian`, `directional`, `mixed_partial`, and `hessian`
-([#141], `8f374bd`). `divergence`, `curl`, `strain_rate`, `rotation_rate`, `custom`, and `regrid` were not
-affected. The keyword constructors and the short trailing-basis forms (`partial(data, order, dim, basis)` etc.)
-are unchanged, as are the positional and Hermite constructors on `RadialBasisOperator` itself.
+([#141], `8f374bd`), and later in the same release from `RadialBasisOperator` itself and `custom`, so the
+`eval_points` keyword is now the only way to supply evaluation points. `divergence`, `curl`, `strain_rate`,
+and `rotation_rate` were not affected. `regrid(data, eval_points)` keeps its positional form — there it is
+the primary source→target signature, not a back-compat tier. The keyword constructors and the short
+trailing-basis forms (`partial(data, order, dim, basis)`, `RadialBasisOperator(ℒ, data, basis)`,
+`custom(data, ℒ, basis)`, etc.) are unchanged.
 
 ```julia
 # before (0.5.x)                                    # after (0.6.0)
@@ -25,6 +28,8 @@ partial(data, eval_points, order, dim, basis)       partial(data, order, dim; ev
 directional(data, eval_points, v, basis)            directional(data, v; eval_points, basis)
 mixed_partial(data, eval_points, i, j, basis)       mixed_partial(data, i, j; eval_points, basis)
 gradient(data, eval_points, basis)                  gradient(data; eval_points, basis)
+RadialBasisOperator(ℒ, data, eval_points, basis)    RadialBasisOperator(ℒ, data; eval_points, basis)
+custom(data, eval_points, ℒ, basis)                 custom(data, ℒ; eval_points, basis)
 
 # Hermite (6–8 positional args) → the `hermite` keyword
 laplacian(data, eval_points, basis,                 laplacian(data; eval_points, basis,

--- a/src/operators/custom.jl
+++ b/src/operators/custom.jl
@@ -68,34 +68,5 @@ function custom(data::AbstractVector, ℒ::Function, basis::AbstractRadialBasis;
     return RadialBasisOperator(Custom{rank}(ℒ), data; basis = basis, kw...)
 end
 
-function custom(
-        data::AbstractVector,
-        eval_points::AbstractVector,
-        ℒ::Function,
-        basis::AbstractRadialBasis = PHS(3; poly_deg = 2);
-        rank::Int = _infer_rank(ℒ),
-        kw...,
-    )
-    return RadialBasisOperator(Custom{rank}(ℒ), data; eval_points = eval_points, basis = basis, kw...)
-end
-
-# Hermite backward compatibility (positional boundary arguments)
-function custom(
-        data::AbstractVector,
-        eval_points::AbstractVector,
-        ℒ::Function,
-        basis::AbstractRadialBasis,
-        is_boundary::Vector{Bool},
-        boundary_conditions::Vector{<:BoundaryCondition},
-        normals::Vector{<:AbstractVector};
-        rank::Int = _infer_rank(ℒ),
-        kw...,
-    )
-    hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals)
-    return RadialBasisOperator(
-        Custom{rank}(ℒ), data; eval_points = eval_points, basis = basis, hermite = hermite, kw...
-    )
-end
-
 # pretty printing
 print_op(::Custom) = "Custom Operator"

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -158,40 +158,6 @@ function RadialBasisOperator(
     return RadialBasisOperator(ℒ, data; basis = basis, k = k, adjl = adjl, device = device)
 end
 
-# Data + eval_points + basis (positional)
-function RadialBasisOperator(
-        ℒ::AbstractOperator,
-        data::AbstractVector,
-        eval_points::AbstractVector,
-        basis::AbstractRadialBasis;
-        k::Int = autoselect_k(data, basis),
-        adjl = find_neighbors(data, eval_points, k),
-        device = get_backend(data),
-    )
-    return RadialBasisOperator(
-        ℒ, data; eval_points = eval_points, basis = basis, k = k, adjl = adjl, device = device
-    )
-end
-
-# Hermite-compatible constructor (positional boundary arguments)
-function RadialBasisOperator(
-        ℒ::AbstractOperator,
-        data::AbstractVector,
-        eval_points::AbstractVector,
-        basis::AbstractRadialBasis,
-        is_boundary::Vector{Bool},
-        boundary_conditions::Vector{<:BoundaryCondition},
-        normals::Vector{<:AbstractVector};
-        k::Int = autoselect_k(data, basis),
-        adjl = find_neighbors(data, eval_points, k),
-        device = get_backend(data),
-    )
-    hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals)
-    return RadialBasisOperator(
-        ℒ, data; eval_points = eval_points, basis = basis, k = k, adjl = adjl, hermite = hermite, device = device
-    )
-end
-
 dim(op::RadialBasisOperator) = length(first(op.data))
 
 # caching

--- a/test/operators/custom.jl
+++ b/test/operators/custom.jl
@@ -42,14 +42,16 @@ end
 end
 
 @testset "custom() Different Eval Points" begin
-    # Test custom.jl lines 47-55: separate evaluation points
     x2 = SVector{2}.(HaltonPoint(2)[(N + 1):(N + 100)])
-    op = custom(x, x2, basis -> (x, xᵢ) -> basis(x, xᵢ); rank = 0)
+    op = custom(x, basis -> (x, xᵢ) -> basis(x, xᵢ); eval_points = x2, rank = 0)
     @test op isa RadialBasisOperator
     @test length(op.eval_points) == 100
 
     # With explicit basis
-    op2 = custom(x, x2, basis -> (x, xᵢ) -> basis(x, xᵢ), PHS(5; poly_deg = 3); rank = 0)
+    op2 = custom(
+        x, basis -> (x, xᵢ) -> basis(x, xᵢ);
+        eval_points = x2, basis = PHS(5; poly_deg = 3), rank = 0,
+    )
     @test op2 isa RadialBasisOperator
 end
 
@@ -208,7 +210,6 @@ end
 end
 
 @testset "custom() Hermite Boundary Conditions" begin
-    # Test custom.jl lines 58-72: Hermite interpolation with boundary conditions
     # Create a simple 1D domain for testing
     spacing = 0.1
     domain = [SVector{1}(x) for x in 0.0:spacing:1.0]
@@ -228,12 +229,9 @@ end
     # Test that the constructor works
     op = custom(
         domain,
-        domain,
-        basis -> (x, xᵢ) -> basis(x, xᵢ),
-        PHS(3; poly_deg = 2),
-        is_boundary,
-        boundary_conditions,
-        normals;
+        basis -> (x, xᵢ) -> basis(x, xᵢ);
+        basis = PHS(3; poly_deg = 2),
+        hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals),
         rank = 0,
     )
     @test op isa RadialBasisOperator

--- a/test/operators/device_kwarg.jl
+++ b/test/operators/device_kwarg.jl
@@ -77,11 +77,6 @@ end
     # Data + basis (positional)
     op1 = RadialBasisOperator(Partial(1, 1), x, PHS(3; poly_deg = 2); device = cpu)
     @test op1.device isa CPU
-
-    # Data + eval_points + basis (positional)
-    x2 = SVector{2}.(HaltonPoint(2)[101:150])
-    op2 = RadialBasisOperator(Partial(1, 1), x, x2, PHS(3; poly_deg = 2); device = cpu)
-    @test op2.device isa CPU
 end
 
 # ============================================================================

--- a/test/operators/operators.jl
+++ b/test/operators/operators.jl
@@ -53,9 +53,8 @@ end
 end
 
 @testset "RadialBasisOperator Constructors" begin
-    # Test positional eval_points + basis constructor (operators.jl lines 114-125)
     x2 = SVector{2}.(HaltonPoint(2)[101:150])
-    op = RadialBasisOperator(Partial(1, 1), x, x2, PHS(3; poly_deg = 2))
+    op = RadialBasisOperator(Partial(1, 1), x; eval_points = x2, basis = PHS(3; poly_deg = 2))
     @test op isa RadialBasisOperator
     @test length(op.eval_points) == 50
 end

--- a/test/solve/integration/gradient_end_to_end.jl
+++ b/test/solve/integration/gradient_end_to_end.jl
@@ -27,14 +27,11 @@ import RadialBasisFunctions as RBF
 
     G_op = RBF.RadialBasisOperator(
         jacobian_op,
-        domain_2d,
-        domain_2d,
-        basis_phs,
-        is_boundary,
-        boundary_conditions,
-        normals;
+        domain_2d;
+        basis = basis_phs,
         k = k,
         adjl = adjl,
+        hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals),
     )
 
     @testset "Test 1: Weights Calculation (Forward Problem)" begin

--- a/test/solve/integration/laplacian_end_to_end.jl
+++ b/test/solve/integration/laplacian_end_to_end.jl
@@ -35,14 +35,11 @@ import RadialBasisFunctions as RBF
 
     L_op = RBF.RadialBasisOperator(
         laplacian_op,
-        domain_2d,
-        domain_2d,
-        basis_phs,
-        is_boundary,
-        boundary_conditions,
-        normals;
+        domain_2d;
+        basis = basis_phs,
         k = k,
         adjl = adjl,
+        hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals),
     )
 
     @testset "Test 1: Weights Calculation (Forward Problem)" begin

--- a/test/solve/integration/partial_x_end_to_end.jl
+++ b/test/solve/integration/partial_x_end_to_end.jl
@@ -40,14 +40,11 @@ partial_x_func(x, y) = 2.0 * x
 
     Dx_op = RBF.RadialBasisOperator(
         partial_x_op,
-        domain_2d,
-        domain_2d,
-        basis_phs,
-        is_boundary,
-        boundary_conditions,
-        normals;
+        domain_2d;
+        basis = basis_phs,
         k = k,
         adjl = adjl,
+        hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals),
     )
 
     @testset "Test 1: Weights Calculation (Forward Problem)" begin

--- a/test/solve/integration/partial_y_end_to_end.jl
+++ b/test/solve/integration/partial_y_end_to_end.jl
@@ -34,14 +34,11 @@ partial_y_func(x, y) = 2.0 * y
 
     Dy_op = RBF.RadialBasisOperator(
         partial_y_op,
-        domain_2d,
-        domain_2d,
-        basis_phs,
-        is_boundary,
-        boundary_conditions,
-        normals;
+        domain_2d;
+        basis = basis_phs,
         k = k,
         adjl = adjl,
+        hermite = (is_boundary = is_boundary, bc = boundary_conditions, normals = normals),
     )
 
     @testset "Test 1: Weights Calculation (Forward Problem)" begin


### PR DESCRIPTION
## Summary

Completes the positional-`eval_points` removal started in #141 / `8f374bd`. The `eval_points` keyword on the unified constructor is now the **only** way to supply evaluation points.

**Removed (4 methods):**
- `RadialBasisOperator(ℒ, data, eval_points, basis; ...)`
- `RadialBasisOperator(ℒ, data, eval_points, basis, is_boundary, bcs, normals; ...)` (positional Hermite)
- `custom(data, eval_points, ℒ, basis=...; ...)`
- `custom(data, eval_points, ℒ, basis, is_boundary, bcs, normals; ...)` (positional Hermite)

**Migration:**
```julia
RadialBasisOperator(ℒ, data, eval_points, basis)   →  RadialBasisOperator(ℒ, data; eval_points, basis)
custom(data, eval_points, ℒ, basis)                →  custom(data, ℒ; eval_points, basis)
# positional Hermite args → hermite = (is_boundary = ..., bc = ..., normals = ...)
```

**Deliberately untouched:**
- `regrid(data, eval_points)` and `∂virtual(data, eval_points, dim, Δ, ...)` — the second point set is their primary source→target API, not a back-compat duplicate (∂virtual's two forms also carry different forward/backward-difference defaults).
- The positional-`basis` tier (`RadialBasisOperator(ℒ, data, basis)`, `custom(data, ℒ, basis)`, `regrid(data, eval_points, basis)`) — no `eval_points` involved.

Tests are migrated to the kwarg forms (coverage preserved, including the Hermite path via the `hermite` kwarg). Docs/README/docstrings already documented only the kwarg form; the unreleased 0.6.0 CHANGELOG entry is extended to record this removal. No deprecation shims, per the project's pre-1.0 policy. Breaking, but folds into the already-breaking unreleased 0.6.0.

<sub>🤖 Beep boop — drafted by Claude; Kyle just points at constructors and says "fewer".</sub>