### PR TITLE
fix(basis): construct degree-0 MonomialBasis for any dimension

### DIFF
--- a/src/basis/monomial.jl
+++ b/src/basis/monomial.jl
@@ -24,16 +24,15 @@ end
 degree(::MonomialBasis{Dim, Deg}) where {Dim, Deg} = Deg
 dim(::MonomialBasis{Dim, Deg}) where {Dim, Deg} = Dim
 
-for Dim in (:1, :2, :3)
-    @eval begin
-        function _get_monomial_basis(::Val{$Dim}, ::Val{0})
-            return function basis!(b, x)
-                b[1] = one(_get_underlying_type(x))
-                return nothing
-            end
-        end
-    end
+function _constant_monomial_basis(b, x)
+    b[1] = one(_get_underlying_type(x))
+    return nothing
 end
+
+# Degree-0 basis is the constant `1` in every dimension. Explicit `Val{1}` and generic
+# `Val{Dim}` methods keep this unambiguous against the `Val{1}, Val{N}` method below.
+_get_monomial_basis(::Val{1}, ::Val{0}) = _constant_monomial_basis
+_get_monomial_basis(::Val{Dim}, ::Val{0}) where {Dim} = _constant_monomial_basis
 
 function _get_monomial_basis(::Val{1}, ::Val{N}) where {N}
     function basis!(b, x)

--- a/test/basis/monomial.jl
+++ b/test/basis/monomial.jl
@@ -207,6 +207,13 @@ end
 
     # standard evaluation
     @test all(isapprox.(m(x), [1]))
+
+    # derivatives
+    for i in 1:4
+        @test all(isapprox.(RBF.∂(m, i)(x), [0]))
+        @test all(isapprox.(RBF.∂²(m, i)(x), [0]))
+    end
+    @test all(isapprox.(RBF.∇²(m)(x), [0]))
 end
 
 @testset "Gradient operator (∇)" begin

--- a/test/basis/monomial.jl
+++ b/test/basis/monomial.jl
@@ -198,6 +198,17 @@ end
     @test all(isapprox.(RBF.∇²(m)(x), [0, 0, 0, 0, 0, 0, 0, 2, 2, 2]))
 end
 
+@testset "dim=4, deg=0 - constant basis for higher dimensions" begin
+    x = SVector(2.0, 3.0, 4.0, 5.0)
+
+    m = MonomialBasis(4, 0)
+    @test m isa MonomialBasis
+    @test typeof(m) <: MonomialBasis{4, 0}
+
+    # standard evaluation
+    @test all(isapprox.(m(x), [1]))
+end
+
 @testset "Gradient operator (∇)" begin
     @testset "dim=2, deg=1" begin
         x = SVector(2.0, 3.0)


### PR DESCRIPTION
Closes #148.

`MonomialBasis(dim, 0)` only had specialized degree-0 methods for `dim` 1, 2, and 3, so `dim >= 4` fell through to the generic constructor where the `1:Deg` loop over an empty range produced a `Vector{Vector{Any}}` and `build_monomial_basis` failed to dispatch (`MethodError`). This replaces the three hardcoded methods with a single generic `Val{Dim}, Val{0}` method (the degree-0 basis is just the constant `1` in any dimension), plus an explicit `Val{1}, Val{0}` method to keep dispatch unambiguous against the existing `Val{1}, Val{N}` method.

I could not run the suite locally (no Julia toolchain on this machine), so I added a `dim=4, deg=0` regression test mirroring the existing degree-0 testsets to cover the reported case.
